### PR TITLE
Tile component accessibility for preview & collection click actions & css fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Adding handleClick to the ActionProps interface in the InputLabelAndAction component.
 - Added spacing, type and hoverBackground properties to the Link component.
 - Added VisualTest to the Link stories.
+- Adjusted height for `Tile` component when subTitle is empty
+- Added onKeyDown to `Tile` component for keyboard accessibility
+- Enabled preview visibility of `Tile` component with keyboard access
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,7 @@
 - Adding handleClick to the ActionProps interface in the InputLabelAndAction component.
 - Added spacing, type and hoverBackground properties to the Link component.
 - Added VisualTest to the Link stories.
-- Adjusted height for `Tile` component when subTitle is empty
-- Added onKeyDown to `Tile` component for keyboard accessibility
-- Enabled preview visibility of `Tile` component with keyboard access
+- Adjusted height when subTitle is empty, added keyboard accessibility for click & preview actions of `Tile` component.
 
 ### Breaking changes
 

--- a/src/composite_components/Tile/Tile.tsx
+++ b/src/composite_components/Tile/Tile.tsx
@@ -37,6 +37,7 @@ interface ImageListContextProps {
 const ImageListContext = React.createContext<ImageListContextProps>({});
 const StyledImageListItem = styled(ImageListItem)<ImageListContextProps>(({ theme }) => {
   const { disabled, isChecked } = React.useContext(ImageListContext);
+
   return {
     backgroundColor: isChecked ? theme.palette.action.selectedOpacityModified : theme.palette.background.default,
     border: `1px solid ${theme.palette.border.secondary}`,
@@ -54,6 +55,9 @@ const StyledImageListItem = styled(ImageListItem)<ImageListContextProps>(({ them
       '.image-list-item-bar': {
         backgroundColor: !disabled && theme.palette.action.hover,
       },
+    },
+    '.visible': {
+      opacity: 1,
     },
   };
 });
@@ -115,10 +119,11 @@ const StyledImageListItembar = styled(ImageListItemBar)<ImageListContextProps>((
   const { hasThumbnail } = React.useContext(ImageListContext);
   return {
     padding: '7px',
-    height: '46px',
+    height: 'auto',
     borderTop: hasThumbnail ? `1px solid ${theme.palette.border.secondary}` : 'none',
     '& .MuiImageListItemBar-titleWrap': {
       padding: '0px',
+      marginTop: '3px',
     },
     '& .MuiImageListItemBar-actionIcon': {
       padding: '0px 0px 0px 8px',
@@ -191,6 +196,7 @@ const Tile = (props: TilePropsType) => {
   const subTitleRef = useRef<HTMLDivElement | null>(null);
   const [isTitleOverflowing, setIsTitleOverflowing] = useState(false);
   const [isSubTitleOverflowing, setIsSubTitleOverflowing] = useState(false);
+  const [isOverlayVisible, setIsOverlayVisible] = useState(false);
   const {
     itemId, imageUrl, avatar, itemClickedAction, handlePreviewAction, tileActions, activeItem,
     imageAltName, ariaLabel, ariaLabelledBy, overflowTooltip, tileRef, hideAvatarIfImageIsLoaded,
@@ -242,6 +248,11 @@ const Tile = (props: TilePropsType) => {
       <StyledImageListItem
         key={itemId}
         onClick={(event: React.MouseEvent<HTMLLIElement>) => { return handleTileClick(event, itemId); }}
+        onKeyDown={(event: React.KeyboardEvent<HTMLLIElement>) => {
+          if (event.key === 'Enter') {
+            handleTileClick(event as unknown as React.MouseEvent<HTMLLIElement>, itemId);
+          }
+        }}
         tabIndex={0}
         role="listitem"
         aria-current={activeItem === itemId}
@@ -262,10 +273,12 @@ const Tile = (props: TilePropsType) => {
               alt={imageAltName || ''}
             />
             {!disabled && (
-              <Overlay className="overlay">
+              <Overlay className={`overlay ${isOverlayVisible ? 'visible' : ''}`}>
                 <IconButton
                   data-testid={TileTestIds.TILE_PREVIEW}
                   onClick={(event) => { return handlePreviewAction?.(event, itemId); }}
+                  onFocus={() => { return setIsOverlayVisible(true); }}
+                  onBlur={() => { return setIsOverlayVisible(false); }}
                 >
                   <CustomIconView />
                 </IconButton>
@@ -287,10 +300,12 @@ const Tile = (props: TilePropsType) => {
               alt={imageAltName || ''}
             />
             {!disabled && (
-              <Overlay className="overlay">
+              <Overlay className={`overlay ${isOverlayVisible ? 'visible' : ''}`}>
                 <IconButton
                   data-testid={TileTestIds.TILE_PREVIEW}
                   onClick={(event) => { return handlePreviewAction?.(event, itemId); }}
+                  onFocus={() => { return setIsOverlayVisible(true); }}
+                  onBlur={() => { return setIsOverlayVisible(false); }}
                 >
                   <CustomIconView />
                 </IconButton>
@@ -305,10 +320,12 @@ const Tile = (props: TilePropsType) => {
               {avatar}
             </StyledBox>
             {!disabled && (
-              <Overlay className="overlay">
+              <Overlay className={`overlay ${isOverlayVisible ? 'visible' : ''}`}>
                 <IconButton
                   data-testid={TileTestIds.TILE_PREVIEW}
                   onClick={(event) => { return handlePreviewAction?.(event, itemId); }}
+                  onFocus={() => { return setIsOverlayVisible(true); }}
+                  onBlur={() => { return setIsOverlayVisible(false); }}
                 >
                   <CustomIconView />
                 </IconButton>
@@ -323,10 +340,12 @@ const Tile = (props: TilePropsType) => {
               {avatar}
             </StyledBox>
             {!disabled && (
-              <Overlay className="overlay">
+              <Overlay className={`overlay ${isOverlayVisible ? 'visible' : ''}`}>
                 <IconButton
                   data-testid={TileTestIds.TILE_PREVIEW}
                   onClick={(event) => { return handlePreviewAction?.(event, itemId); }}
+                  onFocus={() => { return setIsOverlayVisible(true); }}
+                  onBlur={() => { return setIsOverlayVisible(false); }}
                 >
                   <CustomIconView />
                 </IconButton>


### PR DESCRIPTION
As part of this PR,
1. Enabled Click action of Tile component through keyboard
2. Enabled Preview icon display & accessible through keyboard
3. Adjusted css according to the design of DAM collection & assets grid view 

![image](https://github.com/HCL-TECH-SOFTWARE/enchanted-react-components/assets/7530472/9cb1530f-9b0a-45b1-8804-3ed5404319bf)
