### PR TITLE
DXQ-39501 - change input field helper tooltip position to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Updated breadcrumb icons to reflect directionality (RTL/LTR)
 - Resolved spacing issues for icon buttons in the panel component.
 - Updated Tooltip title type with React.ReactNode from string so as to accept string as well as html node.
+- Added `tooltipPlacement` prop to the `MultipleSelectChip` & `Autocomplete` component. 
 
 ### Breaking changes
 

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -21,6 +21,7 @@ import Autocomplete from './Autocomplete';
 import { top100Films } from './data';
 import MenuItem from '../Menu/MenuItem';
 import ListItemText from '../List/ListItemText';
+import { TooltipPlacement } from '../Tooltip';
 
 export default {
   title: 'Inputs/Autocomplete',
@@ -49,6 +50,18 @@ export default {
         },
       },
       description: 'Tooltip text hovering on  ? mark for autocomplete component',
+    },
+    tooltipPlacement: {
+      description: 'Tooltip placement.',
+      options: [TooltipPlacement.TOPSTART, TooltipPlacement.TOP, TooltipPlacement.TOPEND, TooltipPlacement.RIGHTSTART, TooltipPlacement.RIGHT, TooltipPlacement.RIGHTEND,
+        TooltipPlacement.BOTTOMEND, TooltipPlacement.BOTTOM, TooltipPlacement.BOTTOMSTART, TooltipPlacement.LEFTEND, TooltipPlacement.LEFT,
+        TooltipPlacement.LEFTSTART],
+      control: { type: 'radio' },
+      table: {
+        defaultValue: {
+          summary: TooltipPlacement.BOTTOM,
+        },
+      },
     },
     placeholder: {
       table: {
@@ -214,6 +227,7 @@ export const ExampleAutocomplete = {
     label: 'Label',
     helperText: 'Helper text',
     helperIconTooltip: 'Some information about that component.',
+    TooltipPlacement: TooltipPlacement.BOTTOM,
     placeholder: 'Placeholder',
     required: true,
     disabled: false,

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -49,7 +49,31 @@ export default {
           summary: 'Some information about that component.',
         },
       },
-      description: 'Tooltip text hovering on  ? mark for autocomplete component',
+      description:
+        'Tooltip text hovering on ? mark for Autocomplete component',
+    },
+    tooltipPlacement: {
+      description: 'Tooltip placement for ? mark for Autocomplete component.',
+      options: [
+        TooltipPlacement.TOPSTART,
+        TooltipPlacement.TOP,
+        TooltipPlacement.TOPEND,
+        TooltipPlacement.RIGHTSTART,
+        TooltipPlacement.RIGHT,
+        TooltipPlacement.RIGHTEND,
+        TooltipPlacement.BOTTOMEND,
+        TooltipPlacement.BOTTOM,
+        TooltipPlacement.BOTTOMSTART,
+        TooltipPlacement.LEFTEND,
+        TooltipPlacement.LEFT,
+        TooltipPlacement.LEFTSTART,
+      ],
+      control: { type: 'radio' },
+      table: {
+        defaultValue: {
+          summary: TooltipPlacement.BOTTOM,
+        },
+      },
     },
     tooltipPlacement: {
       description: 'Tooltip placement.',
@@ -78,7 +102,8 @@ export default {
           summary: true,
         },
       },
-      description: 'Indicates that autocomplete is required field if it is true',
+      description:
+        'Indicates that autocomplete is required field if it is true',
     },
     disabled: {
       control: 'boolean',
@@ -106,7 +131,8 @@ export default {
           summary: false,
         },
       },
-      description: 'If `true`, the input will take up the full width of its container.',
+      description:
+        'If `true`, the input will take up the full width of its container.',
     },
     focused: {
       control: 'boolean',
@@ -137,13 +163,15 @@ export default {
       description: 'If `true` value cannot be editable',
     },
     sx: {
-      description: 'The sx prop lets you work with a superset of CSS that packages all of the style functions exposed in @mui/system .',
+      description:
+        'The sx prop lets you work with a superset of CSS that packages all of the style functions exposed in @mui/system .',
     },
     options: {
       description: 'Array of options.',
     },
     freeSolo: {
-      description: 'If true, the Autocomplete is free solo, meaning that the user input is not bound to provided options.',
+      description:
+        'If true, the Autocomplete is free solo, meaning that the user input is not bound to provided options.',
     },
     actionProps: {
       control: false,
@@ -173,7 +201,8 @@ export default {
           summary: 'medium',
         },
       },
-      description: 'https://mui.com/material-ui/api/autocomplete/#autocomplete-prop-size',
+      description:
+        'https://mui.com/material-ui/api/autocomplete/#autocomplete-prop-size',
     },
     autoFocus: {
       control: false,
@@ -227,7 +256,7 @@ export const ExampleAutocomplete = {
     label: 'Label',
     helperText: 'Helper text',
     helperIconTooltip: 'Some information about that component.',
-    TooltipPlacement: TooltipPlacement.BOTTOM,
+    tooltipPlacement: TooltipPlacement.BOTTOM,
     placeholder: 'Placeholder',
     required: true,
     disabled: false,

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -75,18 +75,6 @@ export default {
         },
       },
     },
-    tooltipPlacement: {
-      description: 'Tooltip placement.',
-      options: [TooltipPlacement.TOPSTART, TooltipPlacement.TOP, TooltipPlacement.TOPEND, TooltipPlacement.RIGHTSTART, TooltipPlacement.RIGHT, TooltipPlacement.RIGHTEND,
-        TooltipPlacement.BOTTOMEND, TooltipPlacement.BOTTOM, TooltipPlacement.BOTTOMSTART, TooltipPlacement.LEFTEND, TooltipPlacement.LEFT,
-        TooltipPlacement.LEFTSTART],
-      control: { type: 'radio' },
-      table: {
-        defaultValue: {
-          summary: TooltipPlacement.BOTTOM,
-        },
-      },
-    },
     placeholder: {
       table: {
         defaultValue: {

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -38,6 +38,7 @@ export interface AutocompleteProps<T, Multiple, DisableClearable, FreeSolo> exte
   nonEdit?: boolean;
   helperText?: string;
   helperIconTooltip?: string;
+  tooltipPlacement?: string;
   label?: string;
   required?: boolean;
   focused?:boolean;
@@ -85,6 +86,7 @@ DisableClearable extends boolean | undefined = undefined, FreeSolo extends boole
     id: inputLabelId,
     label: props.label,
     helperIconTooltip: props.helperIconTooltip,
+    tooltipPlacement: props.tooltipPlacement,
     actionProps: props.actionProps,
     hiddenLabel: props.hiddenLabel,
     isFocus,

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -24,6 +24,7 @@ import { styled } from '@mui/material/styles';
 import { TYPOGRAPHY } from '../theme';
 import InputLabelAndAction, { InputLabelAndActionProps, ActionProps } from '../prerequisite_components/InputLabelAndAction/InputLabelAndAction';
 import TextField, { TextFieldProps } from '../TextField/TextField';
+import { TooltipPlacement } from '../Tooltip';
 
 /**
  * @typedef AutocompleteProps
@@ -38,11 +39,11 @@ export interface AutocompleteProps<T, Multiple, DisableClearable, FreeSolo> exte
   nonEdit?: boolean;
   helperText?: string;
   helperIconTooltip?: string;
-  tooltipPlacement?: string;
+  tooltipPlacement?: TooltipPlacement;
   label?: string;
   required?: boolean;
-  focused?:boolean;
-  hiddenLabel?:boolean;
+  focused?: boolean;
+  hiddenLabel?: boolean;
   size?: 'medium';
   autoFocus?: boolean;
   clearIcon?: React.ReactNode;

--- a/src/composite_components/MultipleSelectChip/MultipleSelectChip.stories.tsx
+++ b/src/composite_components/MultipleSelectChip/MultipleSelectChip.stories.tsx
@@ -24,6 +24,7 @@ import MenuItem from '../../Menu/MenuItem';
 import ListItemIcon from '../../List/ListItemIcon';
 import ListItemText from '../../List/ListItemText';
 import { IFilm, top100Films } from '../../Autocomplete/data';
+import { TooltipPlacement } from '../../Tooltip';
 
 interface IChip {
   label: string;
@@ -56,6 +57,18 @@ export default {
         },
       },
       description: 'Tooltip text hovering on ? mark for MultiSelectChip component',
+    },
+    tooltipPlacement: {
+      description: 'Tooltip placement.',
+      options: [TooltipPlacement.TOPSTART, TooltipPlacement.TOP, TooltipPlacement.TOPEND, TooltipPlacement.RIGHTSTART, TooltipPlacement.RIGHT, TooltipPlacement.RIGHTEND,
+        TooltipPlacement.BOTTOMEND, TooltipPlacement.BOTTOM, TooltipPlacement.BOTTOMSTART, TooltipPlacement.LEFTEND, TooltipPlacement.LEFT,
+        TooltipPlacement.LEFTSTART],
+      control: { type: 'radio' },
+      table: {
+        defaultValue: {
+          summary: TooltipPlacement.BOTTOM,
+        },
+      },
     },
     required: {
       control: 'boolean',
@@ -276,6 +289,7 @@ export const ExampleMultipleSelectChip = {
     label: 'Example label',
     helperText: 'Helper text',
     helperIconTooltip: 'Some information about that component.',
+    tooltipPlacement: TooltipPlacement.BOTTOM,
     placeholder: 'Placeholder',
     required: true,
     disabled: false,

--- a/src/composite_components/MultipleSelectChip/MultipleSelectChip.stories.tsx
+++ b/src/composite_components/MultipleSelectChip/MultipleSelectChip.stories.tsx
@@ -42,8 +42,7 @@ export default {
           summary: false,
         },
       },
-      description:
-        'Indicates the combobox value is invalid.',
+      description: 'Indicates the combobox value is invalid.',
     },
     emptyOptions: {
       control: 'boolean',
@@ -56,7 +55,32 @@ export default {
           summary: 'Some information about that component.',
         },
       },
-      description: 'Tooltip text hovering on ? mark for MultiSelectChip component',
+      description:
+        'Tooltip text hovering on ? mark for MultiSelectChip component',
+    },
+    tooltipPlacement: {
+      description:
+        'Tooltip placement for ? mark for MultiSelectChip component.',
+      options: [
+        TooltipPlacement.TOPSTART,
+        TooltipPlacement.TOP,
+        TooltipPlacement.TOPEND,
+        TooltipPlacement.RIGHTSTART,
+        TooltipPlacement.RIGHT,
+        TooltipPlacement.RIGHTEND,
+        TooltipPlacement.BOTTOMEND,
+        TooltipPlacement.BOTTOM,
+        TooltipPlacement.BOTTOMSTART,
+        TooltipPlacement.LEFTEND,
+        TooltipPlacement.LEFT,
+        TooltipPlacement.LEFTSTART,
+      ],
+      control: { type: 'radio' },
+      table: {
+        defaultValue: {
+          summary: TooltipPlacement.BOTTOM,
+        },
+      },
     },
     tooltipPlacement: {
       description: 'Tooltip placement.',
@@ -77,7 +101,8 @@ export default {
           summary: true,
         },
       },
-      description: 'Indicates that multiSelectchip is required field if it is true',
+      description:
+        'Indicates that multiSelectchip is required field if it is true',
     },
     label: {
       table: {
@@ -96,10 +121,12 @@ export default {
       description: 'The helper text content.',
     },
     sx: {
-      description: 'The system prop that allows defining system overrides as well as additional CSS styles.',
+      description:
+        'The system prop that allows defining system overrides as well as additional CSS styles.',
     },
     placeholder: {
-      description: 'The short hint displayed in the input before the user enters a value.',
+      description:
+        'The short hint displayed in the input before the user enters a value.',
       table: {
         defaultValue: {
           summary: 'Placeholder',
@@ -122,8 +149,7 @@ export default {
           summary: false,
         },
       },
-      description:
-        'If `true`, the label is hidden.',
+      description: 'If `true`, the label is hidden.',
     },
     nonEdit: {
       control: 'boolean',
@@ -141,7 +167,8 @@ export default {
       description: 'If true, the component is disabled.',
     },
     fullWidth: {
-      description: 'If true, the input will take up the full width of its container.',
+      description:
+        'If true, the input will take up the full width of its container.',
       table: {
         defaultValue: {
           summary: false,
@@ -169,8 +196,7 @@ export default {
     },
     clearIcon: {
       control: false,
-      description:
-        'The clear Icon used to clear chips.',
+      description: 'The clear Icon used to clear chips.',
     },
     endAdornmentAction: {
       control: false,

--- a/src/composite_components/MultipleSelectChip/MultipleSelectChip.stories.tsx
+++ b/src/composite_components/MultipleSelectChip/MultipleSelectChip.stories.tsx
@@ -82,18 +82,6 @@ export default {
         },
       },
     },
-    tooltipPlacement: {
-      description: 'Tooltip placement.',
-      options: [TooltipPlacement.TOPSTART, TooltipPlacement.TOP, TooltipPlacement.TOPEND, TooltipPlacement.RIGHTSTART, TooltipPlacement.RIGHT, TooltipPlacement.RIGHTEND,
-        TooltipPlacement.BOTTOMEND, TooltipPlacement.BOTTOM, TooltipPlacement.BOTTOMSTART, TooltipPlacement.LEFTEND, TooltipPlacement.LEFT,
-        TooltipPlacement.LEFTSTART],
-      control: { type: 'radio' },
-      table: {
-        defaultValue: {
-          summary: TooltipPlacement.BOTTOM,
-        },
-      },
-    },
     required: {
       control: 'boolean',
       table: {

--- a/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
+++ b/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
@@ -17,7 +17,7 @@ import MuiInputLabel, { InputLabelProps as MuiInputLabelProps } from '@mui/mater
 import Grid, { GridProps as MuiGridProps } from '@mui/material/Grid';
 import HelpIcon from '@hcl-software/enchanted-icons/dist/carbon/es/help';
 import { styled, Theme } from '@mui/material';
-import Tooltip from '../../Tooltip';
+import Tooltip, { TooltipPlacement } from '../../Tooltip';
 import Link, { LinkProps } from '../../Link';
 
 export interface ActionProps {
@@ -31,7 +31,7 @@ export interface ActionProps {
 export interface InputLabelAndActionProps extends MuiInputLabelProps {
   actionProps?: ActionProps[];
   helperIconTooltip?: string;
-  tooltipPlacement?: string;
+  tooltipPlacement?: TooltipPlacement;
   hiddenLabel?: boolean;
   label?: ReactNode;
   isFocus?: boolean;
@@ -102,11 +102,18 @@ const renderInputLabel = (props: InputLabelAndActionProps) => {
               maxWidth: '120px', // half of default 240px
             },
           };
-        }}
-      >
+        }}>
         {props.label}
       </StyledInputLabel>
-      {props.helperIconTooltip ? <Tooltip title={props.helperIconTooltip} placement={props.tooltipPlacement}><MuiInputHelpIcon color="action" fontSize="small" /></Tooltip> : ''}
+      {props.helperIconTooltip ? (
+        <Tooltip
+          title={props.helperIconTooltip}
+          placement={ props.tooltipPlacement|| TooltipPlacement.BOTTOM }>
+          <MuiInputHelpIcon color='action' fontSize='small' />
+        </Tooltip>
+      ) : (
+        ''
+      )}
     </>
   );
 };

--- a/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
+++ b/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
@@ -105,7 +105,7 @@ const renderInputLabel = (props: InputLabelAndActionProps) => {
       >
         {props.label}
       </StyledInputLabel>
-      {props.helperIconTooltip ? <Tooltip title={props.helperIconTooltip}><MuiInputHelpIcon color="action" fontSize="small" /></Tooltip> : ''}
+      {props.helperIconTooltip ? <Tooltip title={props.helperIconTooltip} placement="top"><MuiInputHelpIcon color="action" fontSize="small" /></Tooltip> : ''}
     </>
   );
 };

--- a/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
+++ b/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
@@ -31,6 +31,7 @@ export interface ActionProps {
 export interface InputLabelAndActionProps extends MuiInputLabelProps {
   actionProps?: ActionProps[];
   helperIconTooltip?: string;
+  tooltipPlacement?: string;
   hiddenLabel?: boolean;
   label?: ReactNode;
   isFocus?: boolean;
@@ -105,7 +106,7 @@ const renderInputLabel = (props: InputLabelAndActionProps) => {
       >
         {props.label}
       </StyledInputLabel>
-      {props.helperIconTooltip ? <Tooltip title={props.helperIconTooltip} placement="top"><MuiInputHelpIcon color="action" fontSize="small" /></Tooltip> : ''}
+      {props.helperIconTooltip ? <Tooltip title={props.helperIconTooltip} placement={props.tooltipPlacement}><MuiInputHelpIcon color="action" fontSize="small" /></Tooltip> : ''}
     </>
   );
 };

--- a/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
+++ b/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
@@ -102,14 +102,16 @@ const renderInputLabel = (props: InputLabelAndActionProps) => {
               maxWidth: '120px', // half of default 240px
             },
           };
-        }}>
+        }}
+      >
         {props.label}
       </StyledInputLabel>
       {props.helperIconTooltip ? (
         <Tooltip
           title={props.helperIconTooltip}
-          placement={ props.tooltipPlacement|| TooltipPlacement.BOTTOM }>
-          <MuiInputHelpIcon color='action' fontSize='small' />
+          placement={props.tooltipPlacement || TooltipPlacement.BOTTOM}
+        >
+          <MuiInputHelpIcon color="action" fontSize="small" />
         </Tooltip>
       ) : (
         ''


### PR DESCRIPTION
Added `tooltipPlacement` prop to the `MultipleSelectChip` & `Autocomplete` component.

<img width="902" alt="image" src="https://github.com/user-attachments/assets/efdc6200-e177-4bfc-b0b8-3744609fcaf6">
