### PR TITLE
Textfield a11y - Correct htmlFor and id attribute for TextField input label and input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 - Added keyboard accessibility to the header in `DataGrid` component
 - Added focus to the input label in `TextField` and `SelectMultiple` components
+- Fixed `TextField` accessibility attributes to read label
 - Fixed the width of the `Tile` action menu and corrected the focus of nested-level `Accordion` component
 - Added a configurable optional property for `Snackbar` position
 

--- a/src/TextField/TextField.stories.tsx
+++ b/src/TextField/TextField.stories.tsx
@@ -56,6 +56,12 @@ export default {
         defaultValue: { summary: TextField.defaultProps?.label },
       },
     },
+    id: {
+      description: 'Attribute to set the id.',
+      table: {
+        defaultValue: { summary: TextField.defaultProps?.id },
+      },
+    },
     helperText: {
       description: 'Attribute to set the helper text.',
       table: {
@@ -162,6 +168,7 @@ export const ExampleTextField = {
     color: 'primary',
     size: 'medium',
     label: 'Label',
+    id: 'input-id',
     helperText: 'Some important text',
     helperIconTooltip: 'Some information about that component.',
     placeholder: 'Placeholder',

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -292,7 +292,7 @@ const getEndAdornment = (props: TextFieldProps, isComboBox: boolean) => {
 };
 
 const getInputLabelAndActionProps = (props: TextFieldProps, isFocus: boolean): InputLabelAndActionProps => {
-  const inputLabelId = props.label && props.id ? `${props.id}-label` : undefined;
+  const inputLabelId = props.id ? `${props.id}-label` : undefined;
   const inputLabelProps: InputLabelAndActionProps = {
     color: props.color,
     disabled: props.disabled,
@@ -384,11 +384,13 @@ const renderInput = (props: TextFieldProps, setIsFocus: React.Dispatch<React.Set
 
 const TextField = React.forwardRef(({ ...props }: TextFieldProps, forwardRef: React.ForwardedRef<unknown>) => {
   const [isFocus, setIsFocus] = React.useState(false);
-  const muiInputLabelProps = getInputLabelAndActionProps(props, isFocus);
   if (!props.id) {
     const id = useId();
     props.id = id;
+  } else {
+    props.id = `${useId()}${props.id}`;
   }
+  const muiInputLabelProps = getInputLabelAndActionProps(props, isFocus);
   const muiFormControlProps = getMuiFormControlProps(props, forwardRef);
   return (
     <TextFieldContainer>

--- a/src/__tests__/unit/TextField/TextField.test.tsx
+++ b/src/__tests__/unit/TextField/TextField.test.tsx
@@ -136,4 +136,45 @@ describe('TextField', () => {
     expect(container.querySelector('input')).toBeNull();
     expect(container.querySelector('textarea')).not.toBeNull();
   });
+
+  it('Render with a11y attributes', () => {
+    const { container } = render(<TextField helperText="Some important text" />);
+    const label = container.querySelector('label');
+    const input = container.querySelector('input');
+    const helperText = container.querySelector('p');
+
+    if (!label) {
+      throw new Error('Label is not found');
+    }
+    if (!input) {
+      throw new Error('Input is not found');
+    }
+    if (!helperText) {
+      throw new Error('Helper text is not found');
+    }
+
+    expect(label.getAttribute('for')).toBe(input.id);
+    expect(input.getAttribute('aria-describedby')).toBe(helperText.id);
+  });
+
+  it('Renders with a11y attributes and the provided id', () => {
+    const id = 'input-id';
+    const { container } = render(<TextField id={id} helperText="Some important text" />);
+    const label = container.querySelector('label');
+    const input = container.querySelector('input');
+    const helperText = container.querySelector('p');
+
+    if (!label) {
+      throw new Error('Label is not found');
+    }
+    if (!input) {
+      throw new Error('Input is not found');
+    }
+    if (!helperText) {
+      throw new Error('Helper text is not found');
+    }
+
+    expect(label.getAttribute('for')).toBe(input.id);
+    expect(input.getAttribute('aria-describedby')).toBe(helperText.id);
+  });
 });

--- a/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
+++ b/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
@@ -70,15 +70,14 @@ export const StyledInputLabel = styled(MuiInputLabel)((theme) => {
 });
 
 const getMuiInputLabelProps = (props: InputLabelAndActionProps): MuiInputLabelProps => {
-  const inputLabelId = props.label && props.id ? `${props.id}-label` : undefined;
   const inputLabelProps: MuiInputLabelProps = {
     color: props.color,
     disabled: props.disabled,
     error: props.error,
     required: props.required,
     sx: props.sx,
-    htmlFor: props.id,
-    id: inputLabelId,
+    htmlFor: props.htmlFor,
+    id: props.id,
   };
   return inputLabelProps;
 };


### PR DESCRIPTION
The a11y props from https://mui.com/material-ui/react-text-field/#accessibility were slightly misaligned as there was a duplicate label calculation function.
This PR introduces the id as an optional field to define the id to use for the attributes `for`, `id`, and `aria-describedby`, and corrects the internal usage of the id to relate the fields of the FormControl.

Before:
![Screenshot 2024-12-16 at 09 40 28](https://github.com/user-attachments/assets/ce550a5f-e046-4e01-989e-32f4ce2f8aba)

After:
![Screenshot 2024-12-16 at 09 40 11](https://github.com/user-attachments/assets/79aa0c30-6b33-4f9e-9492-0a0dd6bea452)
