### PR TITLE
Added role for screen readers to announce the snackbar message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - Corrected the focus styling of `preview icon` in the `Tile` component and `zoom buttons` in the `Preview` component to meet the required contrast ratio
 - Corrected the focus styling of endActionButtons in `DataGrid` component.
+- Added `role="alert"` to the snackbar message text for improved screen reader accessibility.
 
 ### Changed
 - Added keyboard accessibility to the header in `DataGrid` component

--- a/src/Snackbar/Snackbar.tsx
+++ b/src/Snackbar/Snackbar.tsx
@@ -242,6 +242,7 @@ const Snackbar = ({ ...props }: SnackbarProps) => {
       <Box>
         { getStatusIcon(rest.variant) }
         <Typography
+          role="alert" // for screen readers to announce the message
           variant="body2"
           data-testid={SnackbarTestIds.SNACKBAR_MESSAGE}
           {...buttonText && { 'data-buttontext': buttonText }}


### PR DESCRIPTION
Added `role="alert"` to the snackbar message text for improved screen reader accessibility.