### PR TITLE
Pagination a11y - Add aria-label to Show rows and Page field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Corrected the focus styling of `preview icon` in the `Tile` component and `zoom buttons` in the `Preview` component to meet the required contrast ratio
 - Corrected the focus styling of endActionButtons in `DataGrid` component.
 - Added `role="alert"` to the snackbar message text for improved screen reader accessibility.
+- Added `aria-label` to the input fields for the pagination row label and page label to enhance screen reader accessibility.
 
 ### Changed
 - Added keyboard accessibility to the header in `DataGrid` component

--- a/src/Pagination/CustomTablePaginationActions.tsx
+++ b/src/Pagination/CustomTablePaginationActions.tsx
@@ -78,6 +78,8 @@ const CustomTablePaginationActions = (props: CustomTablePaginationActionsProps) 
         { atLeast480px
           && <Typography variant="body2" data-testid={TablePaginationTestIds.TABLE_PAGINATION_ROWS_LABEL}>{translation.rowsPerPageLabel}</Typography>}
         <Autocomplete
+          aria-label={translation.rowsPerPageLabel}
+          tabIndex={0}
           noOptionsText=""
           options={rowsPerPageOptions}
           getOptionLabel={(option) => { return (Number(option)).toString(); }}
@@ -174,6 +176,8 @@ const CustomTablePaginationActions = (props: CustomTablePaginationActionsProps) 
         { atLeast480px
           && <Typography variant="body2" data-testid={TablePaginationTestIds.TABLE_PAGINATION_PAGE_LABEL}>{translation.pageLabel}</Typography>}
         <Autocomplete
+          aria-label={translation.pageLabel}
+          tabIndex={0}
           noOptionsText=""
           options={Array.from(Array(Math.ceil(count / rowsPerPage)).keys())}
           getOptionLabel={(option) => { return (Number(option) + 1).toString(); }}

--- a/src/__tests__/unit/Pagination/Pagination.test.tsx
+++ b/src/__tests__/unit/Pagination/Pagination.test.tsx
@@ -166,4 +166,26 @@ describe('TablePagination', () => {
     expect(screen.queryByTestId(TablePaginationTestIds.TABLE_PAGINATION_ROWS_DIV)).toBeNull();
     expect(screen.queryByTestId(TablePaginationTestIds.TABLE_PAGINATION_PAGE_DIV)).toBeNull();
   });
+
+  it('should have correct aria-label for rows per page in pagination', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <Pagination page={0} rowsPerPage={10} count={100} />
+      </ThemeProvider>,
+    );
+    const rowsPerPage = screen.getByLabelText('Show rows:');
+    expect(rowsPerPage).not.toBeNull();
+    expect(rowsPerPage.getAttribute('aria-label')).toBe('Show rows:');
+  });
+
+  it('should have correct aria-label for page number in pagination', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <Pagination page={0} rowsPerPage={10} count={100} />
+      </ThemeProvider>,
+    );
+    const pageNumber = screen.getByLabelText('Page:');
+    expect(pageNumber).not.toBeNull();
+    expect(pageNumber.getAttribute('aria-label')).toBe('Page:');
+  });
 });


### PR DESCRIPTION
- Added `aria-label` to the input field for the pagination row label and page label to enhance screen reader accessibility.