### PR TITLE
Update Dialog component Storybook docs

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,8 +15,8 @@
 
 module.exports = {
   "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/!(hidden_components)/**/*.stories.@(js|jsx|ts|tsx)"
+    "../src/!(hidden_components)/**/*.stories.@(js|jsx|ts|tsx)",
+    "../src/**/*.mdx",
   ],
 
   "addons": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added the `favoritesToggleComponent` props to the `Header` component
 - Added an inverse color variant to the `IconButton` component when `inversecolors` is enabled
 - Added the `darkInverse`, `focusInverse`, and `selectedInverse` colors to the palette
+- Added `Developer Notes` section in `Dialog` component's Storybook Docs
 
 ### Fixed
 - Corrected the focus styling of `preview icon` in the `Tile` component and `zoom buttons` in the `Preview` component to meet the required contrast ratio

--- a/src/Dialog/Dialog.mdx
+++ b/src/Dialog/Dialog.mdx
@@ -1,0 +1,19 @@
+import { Meta, Primary, Canvas, Controls, Stories } from '@storybook/blocks';
+
+import * as DialogStories from './Dialog.stories';
+
+<Meta of={DialogStories} />
+
+# Dialog
+
+<Primary />
+
+<Controls />
+
+<Stories />
+
+### Developer Notes
+
+#### Accessibility
+- When a Dialog is opened, it adds an `aria-hidden="true"` attribute to the root element and its siblings. This prevents screen readers from reading the content behind the Dialog.
+If the screen reader needs to read these contents (e.g., for alerts/snackbars), the `aria-hidden` attribute should be removed first.


### PR DESCRIPTION
- Added developer notes in Dialog component's storybook docs

![image](https://github.com/user-attachments/assets/8ace6e06-6fc1-4f95-a05b-2b27d2420e72)
