### PR TITLE
Simplify consumption with a generalized StyleProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint-fix": "eslint --ext .ts,.tsx --fix src",
     "test-storyshots": "jest --collectCoverage=false --testPathPattern \"__tests__/unit/storyshots-(ltr|rtl).test.ts\"",
     "test": "cross-env NODE_ICU_DATA=node_modules/full-icu CI=true jest --config ./jest.config.js --testTimeout=15000 --testPathPattern \"__tests__/(unit|integration)\" --testPathIgnorePatterns \"__tests__/unit/storyshots-(ltr|rtl).test.ts\"",
-    "test-unit": "CI=true jest --config ./jest.config.js --testPathPattern \"__tests__/unit\" --testTimeout=10000 --testPathIgnorePatterns \"__tests__/unit/storyshots-(ltr|rtl).test.ts\"",
+    "test-unit": "cross-env CI=true jest --config ./jest.config.js --testPathPattern \"__tests__/unit\" --testTimeout=10000 --testPathIgnorePatterns \"__tests__/unit/storyshots-(ltr|rtl).test.ts\"",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/src/DirectionStyleProvider/DirectionStyleProvider.tsx
+++ b/src/DirectionStyleProvider/DirectionStyleProvider.tsx
@@ -24,7 +24,7 @@ export interface DirectionStyleProviderProps {
   children: React.ReactNode;
   direction: ThemeDirectionType;
 }
-
+/** @deprecated use StyleProvider instead */
 const DirectionStyleProvider: React.FC<DirectionStyleProviderProps> = (props: DirectionStyleProviderProps) => {
   const isRtlDirection = props.direction === ThemeDirectionType.RTL;
   // Create rtl cache

--- a/src/StyleProvider/StyleProvider.tsx
+++ b/src/StyleProvider/StyleProvider.tsx
@@ -1,0 +1,124 @@
+/* ======================================================================== *
+ * Copyright 2025 HCL America Inc.                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ * http://www.apache.org/licenses/LICENSE-2.0                               *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ * ======================================================================== */
+import * as React from 'react';
+
+import rtlPlugin from 'stylis-plugin-rtl';
+import { prefixer } from 'stylis';
+import CssBaseline from '@mui/material/CssBaseline';
+import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
+import { CacheProvider } from '@emotion/react';
+import { ThemeProvider } from '@mui/material/styles';
+import createCache from '@emotion/cache';
+import {
+  ThemeDirectionType,
+  ThemeModeType,
+  ThemeCssBaselineType,
+  createEnchantedTheme,
+} from '../theme';
+
+export interface StyleProviderProps {
+  children: React.ReactNode;
+  /**
+   * Optional - The theme direction to apply. Default is ThemeDirectionType.LTR.
+   */
+  direction?: ThemeDirectionType;
+  /**
+   * Optional - The theme mode to apply. Default is ThemeModeType.LIGHT_NEUTRAL_GREY.
+   */
+  mode?: ThemeModeType;
+  /**
+   * Optional - The CSS baseline to apply. Default is ThemeCssBaselineType.GLOBAL.
+   * Note: Use for special cases only.
+   */
+  cssBaseline?: ThemeCssBaselineType;
+  /**
+   * Optional - The nonce attribute to add to the style tag for Content Security Policy (CSP) support.
+   */
+  nonce?: string;
+  /**
+   * Optional - Customizations to apply to the Enchanted theme.
+   * Note: Use for special cases only.
+   */
+  themeOverrides?: object;
+}
+
+// Extend the Window interface to include styleNonce
+// TODO - is this really the way to access a global with TypeScript??
+declare global {
+  interface Window {
+    styleNonce?: string;
+  }
+}
+
+const StyleProvider: React.FC<StyleProviderProps> = (props: StyleProviderProps) => {
+  // look for <html dir="rtl">
+  const htmlPageDirection = document.documentElement.getAttribute('dir') === 'rtl' ? ThemeDirectionType.RTL : ThemeDirectionType.LTR;
+  const direction: ThemeDirectionType = props.direction || htmlPageDirection;
+  const themeMode = props.mode || ThemeModeType.LIGHT_NEUTRAL_GREY;
+  const cssBaselineType = props.cssBaseline || ThemeCssBaselineType.GLOBAL;
+
+  // Create Emotion cache
+  const cacheProps = {
+    key: 'emui',
+    stylisPlugins: [prefixer],
+    nonce: '',
+  };
+  if (props.nonce) {
+    cacheProps.nonce = props.nonce;
+  } else if (typeof window !== 'undefined' && typeof window.styleNonce === 'string') {
+    cacheProps.nonce = window.styleNonce;
+  }
+  if (direction === ThemeDirectionType.RTL) {
+    cacheProps.stylisPlugins.push(rtlPlugin);
+  }
+  const cache = createCache(cacheProps);
+
+  const enchantedTheme = createEnchantedTheme(direction, themeMode, props.themeOverrides);
+
+  let cssBaseline;
+  switch (cssBaselineType) {
+    case ThemeCssBaselineType.SCOPED:
+      cssBaseline = (
+        <ScopedCssBaseline>
+          {props.children}
+        </ScopedCssBaseline>
+      );
+      break;
+    case ThemeCssBaselineType.NONE:
+      // no CSS baseline (consuming project is responsible for "reset" styles)
+      cssBaseline = <>{props.children}</>;
+      break;
+    default:
+      cssBaseline = (
+        <>
+          <CssBaseline />
+          {props.children}
+        </>
+      );
+      break;
+  }
+
+  return (
+    <CacheProvider value={cache}>
+      <ThemeProvider theme={enchantedTheme}>
+        <div dir={direction}>
+          {cssBaseline}
+        </div>
+      </ThemeProvider>
+    </CacheProvider>
+  );
+};
+
+export default StyleProvider;

--- a/src/StyleProvider/index.ts
+++ b/src/StyleProvider/index.ts
@@ -12,23 +12,7 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  * ======================================================================== */
+import StyleProvider from './StyleProvider';
 
-import React from 'react';
-
-import StyleProvider from '../../src/StyleProvider';
-import { ThemeDirectionType, ThemeModeType } from '../../src/theme';
-
-
-export const withThemeProvider = (Story, context) => {
-  const themeDirection = context.globals.themeDirection || ThemeDirectionType.RTL;
-  const themeMode = context.globals.theme || ThemeModeType.LIGHT_NEUTRAL_GREY;
-  document.documentElement.removeAttribute("dir");
-  if (themeDirection === ThemeDirectionType.RTL) {
-    document.documentElement.setAttribute("dir", "rtl");
-  }
-  return (
-    <StyleProvider direction={themeDirection} mode={themeMode}>
-      <Story {...context} />
-    </StyleProvider>
-  )
-}
+export default StyleProvider;
+export * from './StyleProvider';

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,8 @@ export { default as Select } from './Select';
 export * from './Select';
 export { default as Snackbar } from './Snackbar';
 export * from './Snackbar';
+export { default as StyleProvider } from './StyleProvider';
+export * from './StyleProvider';
 export { default as Switch } from './Switch';
 export * from './Switch';
 export { default as Table } from './Table';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -415,6 +415,23 @@ export enum ThemeDirectionType {
   RTL = 'rtl',
 }
 
+/**
+ * See "CSS Baseline" in MUI docs for more information.
+ */
+export enum ThemeCssBaselineType {
+  /**
+   * Applies baseline "reset" styles globally.
+  */
+  GLOBAL = 'global',
+  /**
+   * Applies baseline "reset" styles scoped to the children of <StyleProvider>. */
+  SCOPED = 'scoped',
+  /**
+   * No CSS baseline. The consuming project is responsible for "reset" styles.
+   */
+  NONE = 'none'
+}
+
 // Shadow Tokens used in various components are defined as elevation levels below.
 const shadows: Shadows = Array(25).fill('none') as Shadows;
 shadows[0] = 'none';
@@ -470,9 +487,9 @@ const getThemeOptions = (direction: ThemeDirectionType, mode: ThemeModeType) => 
   return themeOptions;
 };
 
-export const createEnchantedTheme = (direction: ThemeDirectionType, mode: ThemeModeType): Theme => {
+export const createEnchantedTheme = (direction: ThemeDirectionType, mode: ThemeModeType, styleOverrides?: object): Theme => {
   const themeOptions: ThemeOptions = getThemeOptions(direction, mode);
-  const enchantedTheme = createTheme(themeOptions);
+  const enchantedTheme = createTheme(themeOptions, styleOverrides || {});
   return enchantedTheme;
 };
 


### PR DESCRIPTION
**work in progress**

The expected outcome is an abstraction of the mechanics of styling an app (or an isolated component) with "Enchanted"
For example:

Preamble:
```jsx
import React from 'react';
import StyleProvider from '@hcl-software/enchanted-react-components/dist/StyleProvider ';
import MyRootComponent from '...';
```
Simplest:
```jsx
export const MyEnchantedApp = () => {
  return (
    <StyleProvider>
      <MyRootComponent >
    </StyleProvider>
  )
}
```

Most complex: 
```jsx
export const MyEnchantedApp = () => {
 const themeOverrides = {
   ...
 };
  return (
    <StyleProvider 
      direction="rtl" 
      mode="LightCoolGrey" 
      nonce="abc123" 
      cssBaseline="scoped" 
      themeOverrides={themeOverrides}
    >
      <MyRootComponent >
    </StyleProvider>
  )
}
```


