### PR TITLE
Added subTitle to the DataGridCell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- Added `subTitle` to the `DataGridCell` component to display additional subtitle text in the row data.
 
 ### Fixed
 

--- a/src/DataGrid/DataGrid.stories.tsx
+++ b/src/DataGrid/DataGrid.stories.tsx
@@ -17,7 +17,10 @@ import React from 'react';
 import { StoryFn, Meta } from '@storybook/react';
 import { GridSortModel, GridColumnVisibilityModel } from '@mui/x-data-grid';
 import DataGrid from './DataGrid';
-import { processRow, sampleColumns, sampleRows } from './sampleData';
+import {
+  processRow, sampleColumns, sampleColumnsWithSubTitle, sampleRows,
+  sampleRowsWithSubTitle,
+} from './sampleData';
 import Typography from '../Typography';
 
 export default {
@@ -236,6 +239,39 @@ const VisualTestTemplate: StoryFn<typeof DataGrid> = (args) => {
             setPage(newPage);
           }}
           totalCount={sampleRows.length}
+          columnVisibilityModel={columnVisibilityState}
+          onColumnVisibilityModelChange={handleColumnVisibilityModelChange}
+          initialState={{
+            sorting: {
+              sortModel: [{ field: 'title', sort: 'asc' }],
+            },
+          }}
+          sortModel={sortState}
+          onSortModelChange={handleSortModelChange}
+        />
+      </div>
+      &nbsp;
+      <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+        DataGrid with SubTitle
+      </Typography>
+      <div style={{ width: '100%' }}>
+        <DataGrid
+          {...args}
+          rows={sampleRowsWithSubTitle}
+          columns={sampleColumnsWithSubTitle}
+          checkboxSelection
+          pageSize={pageSize}
+          page={page}
+          onPageSizeChange={(value) => {
+            if (!Number.isNaN(value) && DataGrid.defaultProps.rowsPerPageOptions.includes(value)) {
+              setPage(0);
+              setPageSize(value);
+            }
+          }}
+          onPageChange={(newPage) => {
+            setPage(newPage);
+          }}
+          totalCount={sampleRowsWithSubTitle.length}
           columnVisibilityModel={columnVisibilityState}
           onColumnVisibilityModelChange={handleColumnVisibilityModelChange}
           initialState={{

--- a/src/DataGrid/DataGrid.tsx
+++ b/src/DataGrid/DataGrid.tsx
@@ -305,11 +305,7 @@ const StyledDataGrid = styled(MuiDataGrid)<DataGridProps>((props) => {
 });
 
 /**
-* Renders a data grid, its replaces table component
-* We have used plain javascripts code since some of the components are not exposed and there are need of keyboard navigation.
-* We are navigating thru html tag using event.
-* Demo:
-* https://pages.git.cwp.pnp-hcl.com/websphere-portal-incubator/enchanted-material-ui-core/?path=/story/data-display-datagrid--example-data-grid
+* Renders a data grid, it replaces the table component.
 */
 const DataGrid = ({ components, componentsProps, ...props }: DataGridProps) => {
   const {

--- a/src/DataGrid/DataGrid.tsx
+++ b/src/DataGrid/DataGrid.tsx
@@ -37,6 +37,7 @@ import ColumnSortedDescendingIcon from './ColumnSortedDescendingIcon';
  * @member {boolean} endActions If true, the cell will display the endActions in row data
  * @member {boolean} showSortingIcon If true, the column header cell will permanently display the sortIcon
  * @member {string} tooltip If we have tooltip, the cell will display tooltip on hover on the cell
+ * @member {boolean} subTitle If true, the cell will display the subTitle in row data
  */
 export interface ExtendedGridColDef extends GridColDef {
   iconEnd?: boolean,
@@ -45,6 +46,7 @@ export interface ExtendedGridColDef extends GridColDef {
   endActions?: boolean, // always use tabIndex inside your button so i can be focused inside the cell
   showSortingIcon?: boolean,
   tooltip?: string,
+  subTitle?: boolean,
 }
 
 // Style modifier for the column header that ensures always visibility of sorting icon, NOT just on hover which was default behavior

--- a/src/DataGrid/sampleData.tsx
+++ b/src/DataGrid/sampleData.tsx
@@ -34,6 +34,7 @@ interface Person {
   'avatar-fullName'?: React.ReactNode,
   'endActions-fullName'?: React.ReactNode,
   'iconEnd-lastName'?: React.ReactNode,
+  'subTitle-fullName'?: string,
 }
 
 export const sampleColumns: ExtendedGridColDef[] = [
@@ -229,7 +230,7 @@ export const sampleMinimalRows: Person[] = [
   },
 ];
 
-export const processRow = (rows: Person[], isMinimal: boolean) => {
+export const processRow = (rows: Person[], isMinimal: boolean, subTitle?: boolean) => {
   const rowsHolder: Person[] = rows.map((item) => {
     if (item.id) {
       item['iconStart-id'] = <IconDocument />;
@@ -246,6 +247,9 @@ export const processRow = (rows: Person[], isMinimal: boolean) => {
           <IconButton tabIndex={0}><IconOverflowMenuHorizontal /></IconButton>,
         ];
       }
+      if (subTitle) {
+        item['subTitle-fullName'] = 'Fictional character';
+      }
     }
     if (item.lastName) {
       item['iconEnd-lastName'] = <IconDocument />;
@@ -254,3 +258,14 @@ export const processRow = (rows: Person[], isMinimal: boolean) => {
   });
   return rowsHolder;
 };
+
+export const sampleRowsWithSubTitle = processRow(sampleRows, false, true);
+export const sampleColumnsWithSubTitle = sampleColumns.map((col) => {
+  if (col.field === 'fullName') {
+    return {
+      ...col,
+      subTitle: true,
+    };
+  }
+  return col;
+});

--- a/src/DataGridCell/DataGridCell.stories.tsx
+++ b/src/DataGridCell/DataGridCell.stories.tsx
@@ -16,15 +16,16 @@
 import React from 'react';
 import { StoryFn, Meta } from '@storybook/react';
 import DataGridCell from './DataGridCell';
-import DataGrid from '../DataGrid/DataGrid';
+import DataGrid, { ExtendedGridColDef } from '../DataGrid/DataGrid';
+import Typography from '../Typography';
 import {
+  sampleColumns,
   sampleColumnsByDefaultLeft,
   sampleColumnsModifiedRight,
   sampleColumnsMultiStartIconAndTooltip,
-  sampleColumnsWithSubTitle,
   sampleRowContainsAll,
-  sampleRowContainsSubTitle,
   sampleRowMultiStartIconAndTooltip,
+  sampleRows,
   sampleRowsDisabled,
 } from './sampleCellConfig';
 
@@ -48,123 +49,169 @@ export default {
     hideFooter: {
       description: 'If true, the footer will be hidden.',
     },
+    colDef: {
+      control: 'object',
+      description: `Defines the configuration for each column in the DataGridCell. This object allows customization 
+        of the appearance and behavior of each column, having options like iconEnd, iconStart, avatar, endActions, 
+        showSortingIcon, and subTitle, etc.`,
+      table: {
+        type: {
+          summary: 'ExtendedGridColDef',
+          detail: `{
+            iconEnd?: boolean; // If true, an icon will be displayed at the end of the cell.
+            iconStart?: boolean; // If true, an icon will be displayed at the start of the cell.
+            avatar?: boolean; // If true, an avatar will be displayed in the cell.
+            endActions?: boolean; // If true, action buttons will be displayed at the end of the cell.
+            showSortingIcon?: boolean; // If true, a sorting icon will be displayed in the column header.
+            subTitle?: boolean; // If true, a subtitle will be displayed below the main cell content.
+          }`,
+        },
+      },
+    },
+    subTitle: {
+      description: 'Subtitle text to be displayed below the main cell content.',
+      control: 'text',
+    },
+    align: {
+      control: 'select',
+      options: ['left', 'right'],
+      description: 'It allows to align the column values in cells.',
+    },
+    headerAlign: {
+      control: 'select',
+      options: ['left', 'right'],
+      description: 'It allows to align the column header values.',
+    },
+    totalCount: {
+      description: 'Total number of rows for all pages set by the sample data so it cannot be controlled',
+      control: false,
+    },
   },
 } as Meta<typeof DataGridCell>;
 
-const Template: StoryFn<typeof DataGridCell> = (args) => {
-  return (
-    <div style={{ height: 400, width: '100%' }}>
-      <DataGrid rows={sampleRowContainsAll} columns={sampleColumnsByDefaultLeft} {...args} totalCount={1} />
-    </div>
-  );
-};
-
-export const AlignLeft = {
-  render: Template,
-
-  args: {
-    rows: sampleRowContainsAll,
-    columns: sampleColumnsByDefaultLeft,
-    pageSize: 1,
-    checkboxSelection: true,
-    hideFooter: true,
-  },
-};
-
-const AlignRightTemplate: StoryFn<typeof DataGridCell> = (args) => {
-  return (
-    <div style={{ height: 400, width: '100%' }}>
-      <DataGrid rows={sampleRowContainsAll} columns={sampleColumnsModifiedRight} {...args} totalCount={1} />
-    </div>
-  );
-};
-
-export const AlignRight = {
-  render: AlignRightTemplate,
-
-  args: {
-    rows: sampleRowContainsAll,
-    columns: sampleColumnsModifiedRight,
-    pageSize: 1,
-    checkboxSelection: true,
-    hideFooter: true,
-    disableColumnMenu: true,
-  },
-};
-
-export const Subtitle: StoryFn<typeof DataGridCell> = (args) => {
+const InteractiveExampleTemplate: StoryFn<typeof DataGridCell> = (args) => {
+  const updatedColumns = sampleColumns.map((col: ExtendedGridColDef) => {
+    const updatedCol = {
+      ...col,
+      iconEnd: (args.colDef as ExtendedGridColDef).iconEnd,
+      iconStart: (args.colDef as ExtendedGridColDef).iconStart,
+      avatar: (args.colDef as ExtendedGridColDef).avatar,
+      endActions: (args.colDef as ExtendedGridColDef).endActions,
+      subTitle: (args.colDef as ExtendedGridColDef).subTitle,
+      showSortingIcon: (args.colDef as ExtendedGridColDef).showSortingIcon,
+      align: (args as ExtendedGridColDef).align,
+      headerAlign: (args as ExtendedGridColDef).headerAlign,
+    };
+    return updatedCol;
+  });
+  const updatedRows = sampleRows.map((row) => {
+    const updatedRow = {
+      ...row,
+      // eslint-why The 'any' type is used here to allow flexibility in assigning the subtitle value, as it is dynamically generated based on the 'colDef.subTitle' value.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      'subTitle-tableHead': (args.colDef as ExtendedGridColDef).subTitle ? (args as any).subTitle : null,
+    };
+    return updatedRow;
+  });
   return (
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...args}
-        rows={sampleRowContainsSubTitle}
-        columns={sampleColumnsWithSubTitle}
-        totalCount={1}
-        pageSize={1}
-        checkboxSelection
-        hideFooter
-        disableColumnMenu
+        columns={updatedColumns}
+        rows={updatedRows}
       />
     </div>
   );
 };
 
-const DisabledTemplate: StoryFn<typeof DataGridCell> = (args) => {
+export const InteractiveExample = InteractiveExampleTemplate.bind({});
+InteractiveExample.parameters = {
+  options: { showPanel: true },
+};
+InteractiveExample.args = {
+  interactive: true,
+  colDef: {
+    iconEnd: true,
+    iconStart: true,
+    avatar: true,
+    endActions: true,
+    subTitle: true,
+    showSortingIcon: false,
+  },
+  subTitle: 'Fictional character',
+  align: 'left',
+  headerAlign: 'left',
+  rows: sampleRows,
+  columns: sampleColumns,
+  checkboxSelection: true,
+  hideFooter: true,
+  pageSize: 10,
+  totalCount: sampleRows.length,
+};
+
+const VisualTestTemplate: StoryFn<typeof DataGridCell> = (args) => {
   return (
-    <div style={{ height: 400, width: '100%' }}>
-      <DataGrid
-        rows={sampleRowsDisabled}
-        columns={sampleColumnsByDefaultLeft}
-        // add condition to tell if row is disabled
-        isRowSelectable={() => {
-          return false;
-        }}
-        {...args}
-        totalCount={1}
-      />
-    </div>
+    <>
+      <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+        DataGridCell Align Left
+      </Typography>
+      <div style={{ height: 150, width: '100%' }}>
+        <DataGrid
+          {...args}
+          rows={sampleRowContainsAll}
+          columns={sampleColumnsByDefaultLeft}
+        />
+      </div>
+
+      &nbsp;
+      <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+        DataGridCell Align Right
+      </Typography>
+      <div style={{ height: 150, width: '100%' }}>
+        <DataGrid
+          {...args}
+          rows={sampleRowContainsAll}
+          columns={sampleColumnsModifiedRight}
+        />
+      </div>
+
+      &nbsp;
+      <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+        DataGridCell Disabled
+      </Typography>
+      <div style={{ height: 150, width: '100%' }}>
+        <DataGrid
+          {...args}
+          rows={sampleRowsDisabled}
+          columns={sampleColumnsByDefaultLeft}
+          isRowSelectable={() => { return false; }}
+        />
+      </div>
+
+      &nbsp;
+      <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+        DataGridCell MultipleStartIconAndTooltip
+      </Typography>
+      <div style={{ height: 150, width: '100%' }}>
+        <DataGrid
+          {...args}
+          rows={sampleRowMultiStartIconAndTooltip}
+          columns={sampleColumnsMultiStartIconAndTooltip}
+          isRowSelectable={() => { return false; }}
+        />
+      </div>
+    </>
   );
 };
 
-export const Disabled = {
-  render: DisabledTemplate,
-
-  args: {
-    rows: sampleRowsDisabled,
-    columns: sampleColumnsByDefaultLeft,
-    pageSize: 1,
-    checkboxSelection: true,
-    hideFooter: true,
-    disableColumnMenu: true,
-  },
+export const VisualTest = VisualTestTemplate.bind({});
+VisualTest.parameters = {
+  options: { showPanel: false },
 };
-
-const MultipleStartIconAndTooltipTemplate: StoryFn<typeof DataGridCell> = (args) => {
-  return (
-    <div style={{ height: 400, width: '100%' }}>
-      <DataGrid
-        rows={sampleRowMultiStartIconAndTooltip}
-        columns={sampleColumnsMultiStartIconAndTooltip}
-        // add condition to tell if row is disabled
-        isRowSelectable={() => {
-          return false;
-        }}
-        totalCount={1}
-        {...args}
-      />
-    </div>
-  );
-};
-
-export const MultipleStartIconAndTooltip = {
-  render: MultipleStartIconAndTooltipTemplate,
-
-  args: {
-    rows: sampleRowMultiStartIconAndTooltip,
-    columns: sampleColumnsMultiStartIconAndTooltip,
-    pageSize: 1,
-    checkboxSelection: true,
-    hideFooter: true,
-    disableColumnMenu: true,
-  },
+VisualTest.args = {
+  pageSize: 1,
+  checkboxSelection: true,
+  hideFooter: true,
+  disableColumnMenu: true,
+  totalCount: 1,
 };

--- a/src/DataGridCell/DataGridCell.stories.tsx
+++ b/src/DataGridCell/DataGridCell.stories.tsx
@@ -21,7 +21,9 @@ import {
   sampleColumnsByDefaultLeft,
   sampleColumnsModifiedRight,
   sampleColumnsMultiStartIconAndTooltip,
+  sampleColumnsWithSubTitle,
   sampleRowContainsAll,
+  sampleRowContainsSubTitle,
   sampleRowMultiStartIconAndTooltip,
   sampleRowsDisabled,
 } from './sampleCellConfig';
@@ -88,6 +90,23 @@ export const AlignRight = {
     hideFooter: true,
     disableColumnMenu: true,
   },
+};
+
+export const Subtitle: StoryFn<typeof DataGridCell> = (args) => {
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        {...args}
+        rows={sampleRowContainsSubTitle}
+        columns={sampleColumnsWithSubTitle}
+        totalCount={1}
+        pageSize={1}
+        checkboxSelection
+        hideFooter
+        disableColumnMenu
+      />
+    </div>
+  );
 };
 
 const DisabledTemplate: StoryFn<typeof DataGridCell> = (args) => {

--- a/src/DataGridCell/DataGridCell.stories.tsx
+++ b/src/DataGridCell/DataGridCell.stories.tsx
@@ -19,13 +19,13 @@ import DataGridCell from './DataGridCell';
 import DataGrid, { ExtendedGridColDef } from '../DataGrid/DataGrid';
 import Typography from '../Typography';
 import {
-  sampleColumns,
+  sampleColumns, sampleColumnsForSubTitle,
   sampleColumnsByDefaultLeft,
   sampleColumnsModifiedRight,
   sampleColumnsMultiStartIconAndTooltip,
   sampleRowContainsAll,
   sampleRowMultiStartIconAndTooltip,
-  sampleRows,
+  sampleRows, sampleRowsForSubTitle,
   sampleRowsDisabled,
 } from './sampleCellConfig';
 
@@ -114,7 +114,7 @@ const InteractiveExampleTemplate: StoryFn<typeof DataGridCell> = (args) => {
     return updatedRow;
   });
   return (
-    <div style={{ height: 400, width: '100%' }}>
+    <div style={{ height: 150, width: '100%' }}>
       <DataGrid
         {...args}
         columns={updatedColumns}
@@ -152,6 +152,18 @@ InteractiveExample.args = {
 const VisualTestTemplate: StoryFn<typeof DataGridCell> = (args) => {
   return (
     <>
+      <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+        DataGridCell SubTitle
+      </Typography>
+      <div style={{ height: 150, width: '100%' }}>
+        <DataGrid
+          {...args}
+          rows={sampleRowsForSubTitle}
+          columns={sampleColumnsForSubTitle}
+        />
+      </div>
+
+      &nbsp;
       <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
         DataGridCell Align Left
       </Typography>

--- a/src/DataGridCell/DataGridCell.tsx
+++ b/src/DataGridCell/DataGridCell.tsx
@@ -167,6 +167,7 @@ const DataGridCell = (props: GridRenderCellParams) => {
       >
         <Tooltip
           title={row[`tooltip-${colDef.field}`] || tooltip}
+          tooltipsize="small"
           componentsProps={{
             tooltip: {
               sx: {

--- a/src/DataGridCell/DataGridCell.tsx
+++ b/src/DataGridCell/DataGridCell.tsx
@@ -30,6 +30,7 @@ const DataGridCell = (props: GridRenderCellParams) => {
   const apiContext = useGridApiContext();
   const valueRef = React.useRef<HTMLDivElement>(null); // add ref to truncate text
   const [tooltip, setTooltip] = React.useState('');
+  const [subTitleTooltip, setSubTitleTooltip] = React.useState('');
   const [innerWidth, setInnerWidth] = React.useState<number>(window.innerWidth);
 
   const handleOnActive = React.useCallback(() => {
@@ -74,11 +75,13 @@ const DataGridCell = (props: GridRenderCellParams) => {
       const isOver = isOverflown(valueRef.current);
       if (isOver) {
         setTooltip(props.value);
+        setSubTitleTooltip(row[`subTitle-${colDef.field}`]);
       } else {
         setTooltip('');
+        setSubTitleTooltip('');
       }
     }
-  }, [valueRef, props.value, innerWidth]);
+  }, [valueRef, props.value, innerWidth, row[`subTitle-${colDef.field}`]]);
 
   const hideEndActions = apiContext.current.getSelectedRows().size > 1 && apiContext.current.isRowSelected(row.id); // hide action button when there is a seleted row/s
   const isAlignRight = colDef.align === 'right';
@@ -148,8 +151,9 @@ const DataGridCell = (props: GridRenderCellParams) => {
       <Grid
         ref={valueRef}
         sx={{ // this grid is for the container of the value of the cell define in col def
-          alignItems: 'center',
+          alignItems: 'flex-start',
           display: 'flex',
+          flexDirection: 'column',
           marginRight: '8px',
           minWidth: '0',
           overflow: 'hidden',
@@ -181,6 +185,30 @@ const DataGridCell = (props: GridRenderCellParams) => {
             {props.value}
           </Typography>
         </Tooltip>
+        {colDef.subTitle && row[`subTitle-${colDef.field}`] && (
+          <Tooltip
+            title={subTitleTooltip}
+            tooltipsize="small"
+            componentsProps={{
+              tooltip: {
+                sx: {
+                  unicodeBidi: (row[`override-bidi-tooltip-${colDef.field}`]) ? 'plaintext' : 'initial',
+                },
+              },
+            }}
+          >
+            <Typography
+              className="MuiDataGrid-cell--subTitle"
+              {...subTitleTooltip && {
+                noWrap: true,
+              }}
+              variant="caption"
+              color="text.secondary"
+            >
+              {row[`subTitle-${colDef.field}`]}
+            </Typography>
+          </Tooltip>
+        )}
       </Grid>
       )}
       {colDef.iconEnd && row[`iconEnd-${colDef.field}`] && (

--- a/src/DataGridCell/sampleCellConfig.tsx
+++ b/src/DataGridCell/sampleCellConfig.tsx
@@ -24,10 +24,12 @@ import IconRainScatteredNight from '@hcl-software/enchanted-icons/dist/carbon/es
 import IconRoadWeather from '@hcl-software/enchanted-icons/dist/carbon/es/road--weather';
 import IconRoadmap from '@hcl-software/enchanted-icons/dist/carbon/es/roadmap';
 import IconRocket from '@hcl-software/enchanted-icons/dist/carbon/es/rocket';
+import IconUser from '@hcl-software/enchanted-icons/dist/carbon/es/user';
+import { GridColumnHeaderParams } from '@mui/x-data-grid';
 import Avatar, { AvatarColors, AvatarTypes } from '../Avatar';
 import IconButton from '../IconButton';
 import DataGridCell from './DataGridCell';
-import { ExtendedGridColDef } from '../DataGrid';
+import { alwaysVisibleColHeadIconModifier, ExtendedGridColDef } from '../DataGrid';
 
 export const baseColumnConfig: ExtendedGridColDef = {
   field: 'baseColumn',
@@ -132,33 +134,6 @@ export const sampleColumnsModifiedRight: ExtendedGridColDef[] = [
   },
 ];
 
-export const sampleColumnsWithSubTitle: ExtendedGridColDef[] = [
-  {
-    ...baseColumnConfig,
-    subTitle: true,
-  },
-  {
-    ...iconEndColumnConfig,
-    subTitle: true,
-  },
-  {
-    ...avatarColumnConfig,
-    subTitle: true,
-  },
-  {
-    ...iconColumnConfig,
-    subTitle: true,
-  },
-  {
-    ...endActionColumnConfig,
-    subTitle: true,
-  },
-  {
-    ...allColumnConfig,
-    subTitle: true,
-  },
-];
-
 export const sampleRowContainsAll = [
   {
     id: '1',
@@ -182,18 +157,6 @@ export const sampleRowContainsAll = [
       <IconButton tabIndex={0}><IconOverflowMenuHorizontal /></IconButton>,
     ],
     all: 'Table row',
-  },
-];
-
-export const sampleRowContainsSubTitle = [
-  {
-    ...sampleRowContainsAll[0],
-    'subTitle-baseColumn': 'Subtitle text-1',
-    'subTitle-iconEndColumn': 'Subtitle text-2',
-    'subTitle-avatarColumn': 'Subtitle text-3',
-    'subTitle-iconStartColumn': 'Subtitle text-4',
-    'subTitle-endActionColumn': 'Subtitle text-5',
-    'subTitle-all': 'Subtitle text-6',
   },
 ];
 
@@ -303,5 +266,39 @@ export const sampleColumnsMultiStartIconAndTooltip: ExtendedGridColDef[] = [
   },
   {
     ...columnTest5,
+  },
+];
+
+export const sampleColumns: ExtendedGridColDef[] = [
+  {
+    field: 'tableHead',
+    headerName: 'Table Head',
+    width: 280,
+    iconEnd: true,
+    avatar: true,
+    iconStart: true,
+    endActions: true,
+    subTitle: true,
+    renderCell: (cellValues) => { return <DataGridCell {...cellValues} />; },
+    headerClassName: (params: GridColumnHeaderParams) => {
+      return (params.colDef as ExtendedGridColDef).showSortingIcon
+        ? alwaysVisibleColHeadIconModifier
+        : '';
+    },
+  },
+];
+
+export const sampleRows = [
+  {
+    id: '1',
+    tableHead: 'Jon Snow',
+    'iconEnd-tableHead': <IconStar />,
+    'avatar-tableHead': <Avatar variant="rounded" iconImage={<IconUser />} />,
+    'iconStart-tableHead': <IconDocument />,
+    'endActions-tableHead': [
+      <IconButton tabIndex={0}><IconEdit /></IconButton>,
+      <IconButton tabIndex={0}><IconOverflowMenuHorizontal /></IconButton>,
+    ],
+    'subTitle-tableHead': 'Fictional character',
   },
 ];

--- a/src/DataGridCell/sampleCellConfig.tsx
+++ b/src/DataGridCell/sampleCellConfig.tsx
@@ -302,3 +302,27 @@ export const sampleRows = [
     'subTitle-tableHead': 'Fictional character',
   },
 ];
+
+export const sampleColumnsForSubTitle: ExtendedGridColDef[] = [
+  sampleColumns[0],
+  {
+    ...sampleColumns[0],
+    field: 'withTooltip',
+    headerName: 'With Tooltip',
+  },
+];
+
+export const sampleRowsForSubTitle = [
+  {
+    ...sampleRows[0],
+    withTooltip: 'Jon Snow',
+    'iconEnd-withTooltip': <IconStar />,
+    'avatar-withTooltip': <Avatar variant="rounded" iconImage={<IconUser />} />,
+    'iconStart-withTooltip': <IconDocument />,
+    'endActions-withTooltip': [
+      <IconButton tabIndex={0}><IconEdit /></IconButton>,
+      <IconButton tabIndex={0}><IconOverflowMenuHorizontal /></IconButton>,
+    ],
+    'subTitle-withTooltip': 'Jon Snow was the son of Rhaegar Targaryen and Lyanna Stark',
+  },
+];

--- a/src/DataGridCell/sampleCellConfig.tsx
+++ b/src/DataGridCell/sampleCellConfig.tsx
@@ -132,6 +132,33 @@ export const sampleColumnsModifiedRight: ExtendedGridColDef[] = [
   },
 ];
 
+export const sampleColumnsWithSubTitle: ExtendedGridColDef[] = [
+  {
+    ...baseColumnConfig,
+    subTitle: true,
+  },
+  {
+    ...iconEndColumnConfig,
+    subTitle: true,
+  },
+  {
+    ...avatarColumnConfig,
+    subTitle: true,
+  },
+  {
+    ...iconColumnConfig,
+    subTitle: true,
+  },
+  {
+    ...endActionColumnConfig,
+    subTitle: true,
+  },
+  {
+    ...allColumnConfig,
+    subTitle: true,
+  },
+];
+
 export const sampleRowContainsAll = [
   {
     id: '1',
@@ -155,6 +182,18 @@ export const sampleRowContainsAll = [
       <IconButton tabIndex={0}><IconOverflowMenuHorizontal /></IconButton>,
     ],
     all: 'Table row',
+  },
+];
+
+export const sampleRowContainsSubTitle = [
+  {
+    ...sampleRowContainsAll[0],
+    'subTitle-baseColumn': 'Subtitle text-1',
+    'subTitle-iconEndColumn': 'Subtitle text-2',
+    'subTitle-avatarColumn': 'Subtitle text-3',
+    'subTitle-iconStartColumn': 'Subtitle text-4',
+    'subTitle-endActionColumn': 'Subtitle text-5',
+    'subTitle-all': 'Subtitle text-6',
   },
 ];
 

--- a/src/__tests__/unit/DataGrid/DataGridCell.test.tsx
+++ b/src/__tests__/unit/DataGrid/DataGridCell.test.tsx
@@ -24,8 +24,7 @@ import DataGrid from '../../../DataGrid';
 import {
   sampleColumnsByDefaultLeft, sampleColumnsModifiedRight, sampleRowContainsAll,
   baseColumnConfig, iconEndColumnConfig, avatarColumnConfig, iconColumnConfig, endActionColumnConfig, allColumnConfig, sampleRowMultiStartIconAndTooltip, sampleColumnsMultiStartIconAndTooltip,
-  sampleRowContainsSubTitle,
-  sampleColumnsWithSubTitle,
+  sampleRows, sampleColumns,
 } from '../../../DataGridCell/sampleCellConfig';
 
 const theme = createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY);
@@ -175,14 +174,14 @@ describe('DataGridCell', () => {
     render(
       <ThemeProvider theme={theme}>
         <DataGrid
-          rows={sampleRowContainsSubTitle}
-          columns={sampleColumnsWithSubTitle}
-          totalCount={sampleRowContainsSubTitle.length}
+          rows={sampleRows}
+          columns={sampleColumns}
+          totalCount={sampleRows.length}
         />
       </ThemeProvider>,
     );
-    expect(screen.getByLabelText(`${avatarColumnConfig.headerName}`)).not.toBeNull();
-    expect((screen.getAllByRole('cell')[0].firstChild?.childNodes[0].lastChild as HTMLElement).classList).toContain('MuiDataGrid-cell--subTitle');
-    expect(screen.getByText('Subtitle text-1')).not.toBeNull();
+    expect(screen.getByLabelText(`${sampleColumns[0].headerName}`)).not.toBeNull();
+    expect((screen.getAllByRole('cell')[0].firstChild?.childNodes[2].lastChild as HTMLElement).classList).toContain('MuiDataGrid-cell--subTitle');
+    expect(screen.getByText('Fictional character')).not.toBeNull();
   });
 });

--- a/src/__tests__/unit/DataGrid/DataGridCell.test.tsx
+++ b/src/__tests__/unit/DataGrid/DataGridCell.test.tsx
@@ -24,6 +24,8 @@ import DataGrid from '../../../DataGrid';
 import {
   sampleColumnsByDefaultLeft, sampleColumnsModifiedRight, sampleRowContainsAll,
   baseColumnConfig, iconEndColumnConfig, avatarColumnConfig, iconColumnConfig, endActionColumnConfig, allColumnConfig, sampleRowMultiStartIconAndTooltip, sampleColumnsMultiStartIconAndTooltip,
+  sampleRowContainsSubTitle,
+  sampleColumnsWithSubTitle,
 } from '../../../DataGridCell/sampleCellConfig';
 
 const theme = createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY);
@@ -167,5 +169,20 @@ describe('DataGridCell', () => {
     expect((screen.getAllByRole('cell')[0]?.firstChild?.firstChild?.firstChild as SVGSVGElement).getAttribute('data-mui-test')).toContain('document--tasksIcon');
     expect((screen.getAllByRole('cell')[1]?.firstChild?.firstChild?.firstChild as SVGSVGElement).getAttribute('data-mui-test')).toContain('starIcon');
     expect((screen.getAllByRole('cell')[2]?.firstChild?.firstChild?.firstChild as SVGSVGElement).getAttribute('data-mui-test')).toContain('radioIcon');
+  });
+
+  it('should render DataGridCell with subTitle when subTitle is present in the data', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <DataGrid
+          rows={sampleRowContainsSubTitle}
+          columns={sampleColumnsWithSubTitle}
+          totalCount={sampleRowContainsSubTitle.length}
+        />
+      </ThemeProvider>,
+    );
+    expect(screen.getByLabelText(`${avatarColumnConfig.headerName}`)).not.toBeNull();
+    expect((screen.getAllByRole('cell')[0].firstChild?.childNodes[0].lastChild as HTMLElement).classList).toContain('MuiDataGrid-cell--subTitle');
+    expect(screen.getByText('Subtitle text-1')).not.toBeNull();
   });
 });


### PR DESCRIPTION
- Added `subTitle` to the `DataGridCell` component to display additional subtitle text in the row data.

<img width="991" alt="Screenshot 2025-01-22 at 2 26 22 PM" src="https://github.com/user-attachments/assets/eeb2bee6-598d-4cb9-802c-e093fd785691" />



Examples - 
<img width="1359" alt="Screenshot 2025-01-22 at 4 42 09 PM" src="https://github.com/user-attachments/assets/d80dfc78-d2b6-4272-8a0f-a70329d3fc1d" />




