### PR TITLE
Fixed a11y issue with pagination label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `aria-erromessage` and `aria-describedby` to the `Autocomplete` component for improved screen reader accessibility.
 - Added a default `id` value to the `Autocomplete` component for making helper text accessible.
 - Fixed screen reader accessibility issue with the pagination `label` in the `Pagination` component.
+- Fixed focus handling on the expand/collapse icon button in the `ProgressBar` component to address accessibility issues
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed the tooltip visibility for the `Panel` component to support keyboard access.
 - Added `aria-erromessage` and `aria-describedby` to the `Autocomplete` component for improved screen reader accessibility.
 - Added a default `id` value to the `Autocomplete` component for making helper text accessible.
+- Fixed screen reader accessibility issue with the pagination `label` in the `Pagination` component.
 
 ### Changed
 

--- a/src/Pagination/CustomTablePaginationActions.tsx
+++ b/src/Pagination/CustomTablePaginationActions.tsx
@@ -75,10 +75,12 @@ const CustomTablePaginationActions = (props: CustomTablePaginationActionsProps) 
   return (
     <Box data-testid={TablePaginationTestIds.TABLE_PAGINATION_ACTIONS_ROOT} sx={{ flexShrink: 0, ml: 2.5 }}>
       <div data-testid={TablePaginationTestIds.TABLE_PAGINATION_ROWS_DIV}>
-        { atLeast480px
-          && <Typography variant="body2" data-testid={TablePaginationTestIds.TABLE_PAGINATION_ROWS_LABEL}>{translation.rowsPerPageLabel}</Typography>}
         <Autocomplete
           aria-label={translation.rowsPerPageLabel}
+          label={translation.rowsPerPageLabel}
+          id={TablePaginationTestIds.TABLE_PAGINATION_ROWS_LABEL}
+          data-testid={TablePaginationTestIds.TABLE_PAGINATION_ROWS_LABEL}
+          role="listbox"
           tabIndex={0}
           noOptionsText=""
           options={rowsPerPageOptions}
@@ -173,10 +175,12 @@ const CustomTablePaginationActions = (props: CustomTablePaginationActionsProps) 
             {theme.direction === ThemeDirectionType.RTL ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
           </IconButton>
         </Tooltip>
-        { atLeast480px
-          && <Typography variant="body2" data-testid={TablePaginationTestIds.TABLE_PAGINATION_PAGE_LABEL}>{translation.pageLabel}</Typography>}
         <Autocomplete
           aria-label={translation.pageLabel}
+          label={translation.pageLabel}
+          id={TablePaginationTestIds.TABLE_PAGINATION_PAGE_LABEL}
+          data-testid={TablePaginationTestIds.TABLE_PAGINATION_PAGE_LABEL}
+          role="listbox"
           tabIndex={0}
           noOptionsText=""
           options={Array.from(Array(Math.ceil(count / rowsPerPage)).keys())}

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -25,7 +25,7 @@ export const getMuiTablePaginationThemeOverrides = (): Components<Omit<Theme, 'c
   return {
     MuiTablePagination: {
       styleOverrides: {
-        root: ({ ownerState }) => {
+        root: ({ ownerState, theme }) => {
           return ({
             borderBottom: 'none',
             '[data-testid=tablePaginationActionsRoot]': {
@@ -59,6 +59,8 @@ export const getMuiTablePaginationThemeOverrides = (): Components<Omit<Theme, 'c
                 },
                 '.MuiFormControl-root': {
                   height: '28px',
+                  display: 'flex',
+                  flexDirection: 'row',
                 },
                 // styles for Change Page Buttons inside TablePagination
                 'button[data-testid=tablePaginationActionsPageFirst]': {
@@ -81,19 +83,25 @@ export const getMuiTablePaginationThemeOverrides = (): Components<Omit<Theme, 'c
                 'div[data-testid=tablePaginationActionsRowsDiv]': {
                   display: 'inline-flex',
                   '.MuiFormLabel-root': {
-                    display: 'none', // hides the form action label space from Autocomplete
+                    maxWidth: 'none',
+                    margin: '6px 4px 6px 0px',
+                    fontWeight: '400',
+                    color: theme.palette.text.primary,
                   },
                   '> .autocomplete-container': {
-                    margin: '0 4px',
+                    marginRight: '4px',
                   },
                 },
                 'div[data-testid=tablePaginationActionsPageDiv]': {
                   display: 'inline-flex',
                   '.MuiFormLabel-root': {
-                    display: 'none', // hides the form action label space from Autocomplete
+                    maxWidth: 'none',
+                    margin: '6px 4px 6px 0px',
+                    fontWeight: '400',
+                    color: theme.palette.text.primary,
                   },
                   '> .autocomplete-container': {
-                    margin: '0 4px',
+                    marginRight: '4px',
                   },
                 },
                 '.MuiTypography-root[data-testid=tablePaginationActionsPageTotal]': {
@@ -150,7 +158,7 @@ const Pagination = ({ ...props }: TablePaginationProps) => {
   return (
     <>
       {props.count > 0 && (
-      <Table>
+      <Table role="presentation">
         <TableFooter>
           <TableRow>
             <MuiTablePagination

--- a/src/__tests__/unit/Pagination/Pagination.test.tsx
+++ b/src/__tests__/unit/Pagination/Pagination.test.tsx
@@ -89,7 +89,7 @@ describe('TablePagination', () => {
 
     const element = screen.getAllByRole('combobox')[0];
     fireEvent.mouseDown(element);
-    const listbox = within(screen.getByRole('listbox'));
+    const listbox = within(screen.getAllByRole('listbox')[2]);
     expect(listbox.getByText('25')).not.toBeNull();
     fireEvent.click(listbox.getByText('25'));
     await waitFor(() => { expect(mockFn).toHaveBeenCalled(); });
@@ -106,7 +106,7 @@ describe('TablePagination', () => {
 
     const element = screen.getAllByRole('combobox')[1];
     fireEvent.mouseDown(element);
-    const listbox = within(screen.getByRole('listbox'));
+    const listbox = within(screen.getAllByRole('listbox')[2]);
     expect(listbox.getByText('5')).not.toBeNull();
     fireEvent.click(listbox.getByText('5'));
     await waitFor(() => { expect(mockFn).toHaveBeenCalled(); });
@@ -173,7 +173,7 @@ describe('TablePagination', () => {
         <Pagination page={0} rowsPerPage={10} count={100} />
       </ThemeProvider>,
     );
-    const rowsPerPage = screen.getByLabelText('Show rows:');
+    const rowsPerPage = screen.getByTestId(TablePaginationTestIds.TABLE_PAGINATION_ROWS_LABEL);
     expect(rowsPerPage).not.toBeNull();
     expect(rowsPerPage.getAttribute('aria-label')).toBe('Show rows:');
   });
@@ -184,7 +184,7 @@ describe('TablePagination', () => {
         <Pagination page={0} rowsPerPage={10} count={100} />
       </ThemeProvider>,
     );
-    const pageNumber = screen.getByLabelText('Page:');
+    const pageNumber = screen.getByTestId(TablePaginationTestIds.TABLE_PAGINATION_PAGE_LABEL);
     expect(pageNumber).not.toBeNull();
     expect(pageNumber.getAttribute('aria-label')).toBe('Page:');
   });

--- a/src/composite_components/ProgressBar/ProgressHeader.tsx
+++ b/src/composite_components/ProgressBar/ProgressHeader.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.                                           *
  * ======================================================================== */
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Box, styled } from '@mui/material';
 import ChevronDownIcon from '@hcl-software/enchanted-icons/dist/carbon/es/chevron--down';
 import ChevronUpIcon from '@hcl-software/enchanted-icons/dist/carbon/es/chevron--up';
@@ -152,6 +152,24 @@ const ProgressHeader = (props: progressHeaderProps) => {
     cancelAll, pauseButton, translation, expanded, toggleButtonClick,
   } = props;
 
+  const collapseButtonRef = useRef<HTMLButtonElement>(null);
+  const expandButtonRef = useRef<HTMLButtonElement>(null);
+  const isFirstRender = useRef(true);
+
+  // Sets focus on the collapseIconButton or expandIconButton when `expanded` state changes.
+  // Skips focus on initial render to avoid auto-focusing on page refresh.
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (expanded && collapseButtonRef.current) {
+      collapseButtonRef.current.focus();
+    } else if (!expanded && expandButtonRef.current) {
+      expandButtonRef.current.focus();
+    }
+  }, [expanded]);
+
   /**
    * Renders an icon based on the total percentage value.
    * @returns The icon component based on the total percentage value.
@@ -219,9 +237,11 @@ const ProgressHeader = (props: progressHeaderProps) => {
                 onClick={toggleButtonClick}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
+                    e.preventDefault();
                     toggleButtonClick();
                   }
                 }}
+                ref={collapseButtonRef}
               >
                 <ChevronUpIcon />
               </IconButton>
@@ -234,9 +254,11 @@ const ProgressHeader = (props: progressHeaderProps) => {
                 onClick={toggleButtonClick}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
+                    e.preventDefault();
                     toggleButtonClick();
                   }
                 }}
+                ref={expandButtonRef}
               >
                 <ChevronDownIcon />
               </IconButton>


### PR DESCRIPTION
- Fixed screen reader accessibility issue with the pagination `label` in the `Pagination` component.
- Fixed focus handling on the expand/collapse icon button in the `ProgressBar` component to address focus accessibility issues