### PR TITLE
Add neutral size option to Button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `subTitle` to the `DataGridCell` component to display additional subtitle text in the row data.
 - Added jest-reporter-log-validator to report on max allowed log counts from component rendering during pull request test check
 - Added `ActionButton` component designed to perform a specific action or task when clicked or tapped.
+- Added `neutral` size control in the `Button` component.
 
 ### Fixed
 - Fixed accessibility issue with `DataGrid` component

--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -32,7 +32,7 @@ export default {
     },
     size: {
       description: 'Sizes of Button component.',
-      options: ['small', 'medium', 'large'],
+      options: ['neutral', 'small', 'medium', 'large'],
       control: { type: 'radio' },
       if: { arg: 'interactive' },
     },
@@ -1080,6 +1080,320 @@ const VisualTestTemplate: StoryFn<typeof Button> = (args) => {
                   className="force-to-focusHover"
                 >
                   Button
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid item>
+        <Grid container direction="column">
+          <Grid item paddingBottom={0}>
+            <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+              Button neutral Contained
+            </Typography>
+          </Grid>
+          <Divider />
+          <Grid item paddingTop={1}>
+            <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+              Active
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container spacing={3}>
+              <Grid item xs={3} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  startIcon={<IconStart />}
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  endIcon={<IconEnd />}
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                >
+                  px
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+              Focus
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container spacing={3}>
+              <Grid item xs={3} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                  className="force-to-focus"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  startIcon={<IconStart />}
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                  className="force-to-focus"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  endIcon={<IconEnd />}
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                  className="force-to-focus"
+                >
+                  px
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+              Disabled
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container spacing={3}>
+              <Grid item xs={3} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                  disabled
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  startIcon={<IconStart />}
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                  disabled
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  endIcon={<IconEnd />}
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                  disabled
+                >
+                  px
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+              Hover & Focus
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container spacing={3}>
+              <Grid item xs={3} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                  className="force-to-focusHover"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  startIcon={<IconStart />}
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                  className="force-to-focusHover"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  endIcon={<IconEnd />}
+                  variant={ButtonVariants.CONTAINED}
+                  size="neutral"
+                  className="force-to-focusHover"
+                >
+                  px
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item paddingTop={3}>
+            <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+              Button neutral Outlined
+            </Typography>
+          </Grid>
+          <Divider />
+          <Grid item paddingTop={1}>
+            <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+              Active
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container spacing={3}>
+              <Grid item xs={3} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  startIcon={<IconStart />}
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  endIcon={<IconEnd />}
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                >
+                  px
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+              Focus
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container spacing={3}>
+              <Grid item xs={3} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                  className="force-to-focus"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  startIcon={<IconStart />}
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                  className="force-to-focus"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  endIcon={<IconEnd />}
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                  className="force-to-focus"
+                >
+                  px
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+              Disabled
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container spacing={3}>
+              <Grid item xs={3} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                  disabled
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  startIcon={<IconStart />}
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                  disabled
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  endIcon={<IconEnd />}
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                  disabled
+                >
+                  px
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            <Typography sx={{ color: 'rgba(0, 0, 0, 0.60);' }} variant="body1">
+              Hover & Focus
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container spacing={3}>
+              <Grid item xs={3} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                  className="force-to-focusHover"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  startIcon={<IconStart />}
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                  className="force-to-focusHover"
+                >
+                  px
+                </Button>
+              </Grid>
+              <Grid item xs={4} paddingBottom={2} sx={{ py: 2.7 }}>
+                <Button
+                  endIcon={<IconEnd />}
+                  variant={ButtonVariants.OUTLINED}
+                  size="neutral"
+                  className="force-to-focusHover"
+                >
+                  px
                 </Button>
               </Grid>
             </Grid>

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -16,6 +16,12 @@ import React from 'react';
 import MuiButton, { ButtonProps as MuiButtonProps } from '@mui/material/Button';
 import { Components, Theme } from '@mui/material';
 
+declare module '@mui/material/Button' {
+  interface ButtonPropsSizeOverrides {
+    neutral: true;
+  }
+}
+
 export enum ButtonVariants {
   CONTAINED = 'contained',
   OUTLINED = 'outlined',
@@ -141,6 +147,130 @@ export const getMuiButtonThemeOverrides = (): Components<Omit<Theme, 'components
                 outline: `${ownerState.inversecolors ? theme.palette.action.selectedInverse : theme.palette.action.selected} 1px solid`,
                 outlineOffset: '2px',
                 backgroundColor: ownerState.inversecolors ? theme.palette.action.hoverInverse : theme.palette.action.hover,
+              },
+            }),
+            // Apply dimension styles for all neutral buttons
+            ...(ownerState.size === 'neutral' && {
+              height: '20px',
+              width: 'auto',
+              minWidth: 'auto',
+              padding: '0 4px',
+            }),
+
+            // neutral + Contained variant styling for primary color
+            ...(ownerState.size === 'neutral' && ownerState.variant === 'contained' && (!ownerState.color || ownerState.color === 'primary') && {
+              color: theme.palette.text.secondary,
+              backgroundColor: theme.palette.action.disabledOpacityModified,
+              border: 'none',
+
+              '&:hover': {
+                backgroundColor: theme.palette.action.disableOpacityHover,
+                color: theme.palette.text.primary,
+              },
+
+              '&.Mui-focusVisible, &.force-to-focus': {
+                backgroundColor: theme.palette.action.disabledOpacityModified,
+                color: theme.palette.text.secondary,
+                outline: `${theme.palette.action.selected} 1px solid`,
+                outlineOffset: '2px',
+              },
+
+              '&.force-to-focusHover': {
+                backgroundColor: theme.palette.action.disableOpacityHover,
+                color: theme.palette.text.primary,
+                outline: `${theme.palette.action.selected} 1px solid`,
+                outlineOffset: '2px',
+              },
+
+              '&.Mui-disabled': {
+                backgroundColor: theme.palette.action.disabledBackground,
+                color: theme.palette.text.disabled,
+              },
+            }),
+
+            // neutral + Outlined variant styling for primary color
+            ...(ownerState.size === 'neutral' && ownerState.variant === 'outlined' && (!ownerState.color || ownerState.color === 'primary') && {
+              color: theme.palette.text.secondary,
+              backgroundColor: 'transparent',
+              borderColor: theme.palette.text.secondary,
+
+              '&:hover': {
+                backgroundColor: theme.palette.action.hover,
+                color: theme.palette.text.primary,
+                borderColor: theme.palette.text.primary,
+              },
+
+              '&.Mui-focusVisible, &.force-to-focus': {
+                backgroundColor: 'transparent',
+                color: theme.palette.text.secondary,
+                borderColor: theme.palette.text.secondary,
+                outline: `${theme.palette.action.selected} 1px solid`,
+                outlineOffset: '2px',
+              },
+
+              '&.force-to-focusHover': {
+                backgroundColor: theme.palette.action.hover,
+                color: theme.palette.text.primary,
+                borderColor: theme.palette.text.primary,
+                outline: `${theme.palette.action.selected} 1px solid`,
+                outlineOffset: '2px',
+              },
+
+              '&.Mui-disabled': {
+                backgroundColor: 'transparent',
+                color: theme.palette.action.disabledBackground,
+                borderColor: theme.palette.action.disabledBackground,
+              },
+            }),
+
+            // non-primary colors for neutral size Contained buttons
+            ...(ownerState.size === 'neutral' && ownerState.variant === 'contained' && ownerState.color && ownerState.color !== 'primary' && {
+              color: theme.palette.action.selected,
+              backgroundColor: theme.palette.action.selectedOpacityModified,
+              border: 'none',
+
+              '&:hover': {
+                backgroundColor: theme.palette.action.selectedOpacityHover,
+              },
+
+              '&.Mui-focusVisible, &.force-to-focus': {
+                backgroundColor: theme.palette.action.selectedOpacityModified,
+                outline: `${theme.palette.action.selected} 1px solid`,
+                outlineOffset: '2px',
+              },
+
+              '&.force-to-focusHover': {
+                backgroundColor: theme.palette.action.selectedOpacityHover,
+                outline: `${theme.palette.action.selected} 1px solid`,
+                outlineOffset: '2px',
+              },
+            }),
+
+            // non-primary colors for neutral size Outlined buttons
+            ...(ownerState.size === 'neutral' && ownerState.variant === 'outlined' && ownerState.color && ownerState.color !== 'primary' && {
+              color: theme.palette.action.selected,
+              backgroundColor: theme.palette.action.selectedOpacityModified,
+              borderColor: theme.palette.action.selected,
+
+              '&:hover': {
+                backgroundColor: theme.palette.action.selectedOpacityHover,
+                borderColor: theme.palette.action.selected,
+              },
+
+              '&.Mui-focusVisible, &.force-to-focus': {
+                backgroundColor: theme.palette.action.selectedOpacityModified,
+                outline: `${theme.palette.action.selected} 1px solid`,
+                outlineOffset: '2px',
+              },
+
+              '&.force-to-focusHover': {
+                backgroundColor: theme.palette.action.selectedOpacityHover,
+                outline: `${theme.palette.action.selected} 1px solid`,
+                outlineOffset: '2px',
+              },
+
+              '&.Mui-disabled': {
+                backgroundColor: theme.palette.action.disabledBackground,
               },
             }),
           });

--- a/src/__tests__/unit/Button/Button.test.tsx
+++ b/src/__tests__/unit/Button/Button.test.tsx
@@ -46,4 +46,9 @@ describe('Button', () => {
     render(<Button inversecolors />);
     expect(screen.findByLabelText('Button')).toBeTruthy();
   });
+
+  it('Render neutral size', () => {
+    render(<Button size="neutral" />);
+    expect(screen.findByLabelText('Button')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
This PR covers the following changes:

- Added a "neutral" option on the size property of the Button component

Design link: https://www.figma.com/design/dnJs5qGUrh1jkQr7y6md7U/branch/gc7YruvOgqnK3naHkgcSNw/HCLED-Components-V2.1?node-id=1338-465763&t=Dq4gTLscP5JNWCZH-0