### PR TITLE
Create Unit Selector component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed flickering issue in the autocomplete component when going to the next or previous page using pagination
 - Fixed accessibility issue with disabled row on `DataGrid` component.
 - Fixing all Textfield based components helpertext position when text direction is RTL. (Textfield based components are DatePicker, Autocomplete, SelectSingle, SelectMultiple)
+- Fixed the issue where the 'Learn more' button shifted when hovering over the list of progress items in the `ProgressBar` component.
 - Fixing the focus issue when there are more than one date picker that are used side by side.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixing the focus issue when there are more than one date picker that are used side by side.
 
 ### Changed
+- Changed `fontWeight` to `normal` for `neutral` size in the `Button` component.
 
 ### Breaking changes
 
@@ -24,6 +25,8 @@
 - Added jest-reporter-log-validator to report on max allowed log counts from component rendering during pull request test check
 - Added `ActionButton` component designed to perform a specific action or task when clicked or tapped.
 - Added `neutral` size control in the `Button` component.
+- Added `UnitSelector` component in `prerequisite_components` to provide unit selection capabilities for the `TextField` component.
+- Added examples of `UnitSelector` integration with `TextField` in storybook.
 
 ### Fixed
 - Fixed accessibility issue with `DataGrid` component

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -155,6 +155,7 @@ export const getMuiButtonThemeOverrides = (): Components<Omit<Theme, 'components
               width: 'auto',
               minWidth: 'auto',
               padding: '0 4px',
+              fontWeight: 'normal',
             }),
 
             // neutral + Contained variant styling for primary color

--- a/src/TextField/TextField.stories.tsx
+++ b/src/TextField/TextField.stories.tsx
@@ -17,8 +17,12 @@ import React from 'react';
 import { StoryFn, Meta } from '@storybook/react';
 import CaretDownIcon from '@hcl-software/enchanted-icons/dist/carbon/es/caret--down';
 
+import InputAdornment from '@mui/material/InputAdornment';
+import { Box } from '@mui/material';
 import TextField from './TextField';
 import Button from '../Button';
+
+import UnitSelector from '../prerequisite_components/UnitSelector/UnitSelector';
 
 export default {
   title: 'Inputs/TextField',
@@ -231,5 +235,85 @@ export const ExampleTextFieldFullWidth = {
   args: {
     ...ExampleTextField.args,
     fullWidth: true,
+  },
+};
+
+export const ExampleTextFieldWithUnitSelector = {
+  render: () => {
+    const [widthValue, setWidthValue] = React.useState('');
+    const [widthUnit, setWidthUnit] = React.useState('px');
+    const [widthFocused, setWidthFocused] = React.useState(false);
+
+    const [heightValue, setHeightValue] = React.useState('');
+    const [heightUnit, setHeightUnit] = React.useState('px');
+    const [heightFocused, setHeightFocused] = React.useState(false);
+
+    const units = ['px', '%', 'em', 'rem', 'vw', 'Freeform'];
+
+    const handleWidthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setWidthValue(event.target.value);
+    };
+
+    const handleWidthUnitChange = (newUnit: string) => {
+      setWidthUnit(newUnit);
+    };
+
+    const handleHeightChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setHeightValue(event.target.value);
+    };
+
+    const handleHeightUnitChange = (newUnit: string) => {
+      setHeightUnit(newUnit);
+    };
+
+    return (
+      <Box sx={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+        <TextField
+          label="Width"
+          value={widthValue}
+          onChange={handleWidthChange}
+          type={widthUnit === 'Freeform' ? 'text' : 'number'}
+          placeholder="Placeholder"
+          sx={{ width: '200px' }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <UnitSelector
+                  units={units}
+                  selectedUnit={widthUnit}
+                  onUnitChange={handleWidthUnitChange}
+                  active={widthFocused}
+                />
+              </InputAdornment>
+            ),
+            onFocus: () => { return setWidthFocused(true); },
+            onBlur: () => { return setWidthFocused(false); },
+          }}
+        />
+
+        <TextField
+          label="Height"
+          value={heightValue}
+          onChange={handleHeightChange}
+          type={heightUnit === 'Freeform' ? 'text' : 'number'}
+          placeholder="Placeholder"
+          sx={{ width: '200px' }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <UnitSelector
+                  units={units}
+                  selectedUnit={heightUnit}
+                  onUnitChange={handleHeightUnitChange}
+                  active={heightFocused}
+                />
+              </InputAdornment>
+            ),
+            onFocus: () => { return setHeightFocused(true); },
+            onBlur: () => { return setHeightFocused(false); },
+          }}
+        />
+      </Box>
+    );
   },
 };

--- a/src/__tests__/unit/UnitSelector/UnitSelector.test.tsx
+++ b/src/__tests__/unit/UnitSelector/UnitSelector.test.tsx
@@ -1,0 +1,144 @@
+/* ======================================================================== *
+ * Copyright 2024 HCL America Inc.                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ * http://www.apache.org/licenses/LICENSE-2.0                               *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ * ======================================================================== */
+
+import React from 'react';
+import {
+  render, screen, cleanup, fireEvent,
+} from '@testing-library/react';
+import { ThemeProvider } from '@emotion/react';
+import { ThemeDirectionType, ThemeModeType, createEnchantedTheme } from '../../../theme';
+
+import UnitSelector from '../../../prerequisite_components/UnitSelector/UnitSelector';
+
+const unitsWithoutFreeform = ['px', 'rem', 'em', '%'];
+const unitsWithFreeform = ['px', 'rem', '%', 'Freeform'];
+const onUnitChange = jest.fn();
+
+afterEach(cleanup);
+
+describe('UnitSelector', () => {
+  it('Render without errrors', () => {
+    render(
+      <ThemeProvider theme={createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY)}>
+        <UnitSelector
+          units={unitsWithoutFreeform}
+          selectedUnit="px"
+          onUnitChange={onUnitChange}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('px')).not.toBeNull();
+  });
+
+  it('Render with the selected unit', () => {
+    render(
+      <ThemeProvider theme={createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY)}>
+        <UnitSelector
+          units={unitsWithoutFreeform}
+          selectedUnit="%"
+          onUnitChange={onUnitChange}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('%')).not.toBeNull();
+  });
+
+  it('Render "ff" when Freeform is the selected unit', () => {
+    render(
+      <ThemeProvider theme={createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY)}>
+        <UnitSelector
+          units={unitsWithFreeform}
+          selectedUnit="Freeform"
+          onUnitChange={onUnitChange}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('ff')).not.toBeNull();
+  });
+
+  it('Render with the first unit if selectedUnit is not in the units array', () => {
+    render(
+      <ThemeProvider theme={createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY)}>
+        <UnitSelector
+          units={unitsWithoutFreeform}
+          selectedUnit="invalid_unit"
+          onUnitChange={onUnitChange}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('px')).not.toBeNull();
+  });
+
+  it('Render and opens the menu when button is clicked', () => {
+    render(
+      <ThemeProvider theme={createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY)}>
+        <UnitSelector
+          units={unitsWithoutFreeform}
+          selectedUnit="px"
+          onUnitChange={onUnitChange}
+        />
+      </ThemeProvider>,
+    );
+
+    const button = screen.getByText('px');
+    fireEvent.click(button);
+
+    expect(screen.getByText('rem')).not.toBeNull();
+    expect(screen.getByText('%')).not.toBeNull();
+  });
+
+  it('Render and displays all provided units in the menu', () => {
+    render(
+      <ThemeProvider theme={createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY)}>
+        <UnitSelector
+          units={unitsWithFreeform}
+          selectedUnit="px"
+          onUnitChange={onUnitChange}
+        />
+      </ThemeProvider>,
+    );
+
+    const button = screen.getByText('px');
+    fireEvent.click(button);
+
+    unitsWithFreeform.forEach((unit) => {
+      expect(screen.getAllByText(unit)).not.toBeNull();
+    });
+  });
+
+  it('Render and calls onUnitChange with the correct unit when menu item is clicked', () => {
+    render(
+      <ThemeProvider theme={createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY)}>
+        <UnitSelector
+          units={unitsWithFreeform}
+          selectedUnit="px"
+          onUnitChange={onUnitChange}
+        />
+      </ThemeProvider>,
+    );
+
+    const button = screen.getByText('px');
+    fireEvent.click(button);
+
+    const remOption = screen.getByText('rem');
+    fireEvent.click(remOption);
+
+    expect(onUnitChange).toHaveBeenCalledWith('rem');
+  });
+});

--- a/src/composite_components/ProgressBar/ProgressItems.tsx
+++ b/src/composite_components/ProgressBar/ProgressItems.tsx
@@ -106,7 +106,21 @@ const StyledList = styled(List)((props) => {
     '.MuiListItem-root': {
       '.MuiListItemButton-root': {
         '.MuiListItemText-root': {
-          marginRight: '8px',
+          '& .MuiListItemText-primary': {
+            maxWidth: '252px',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          },
+          '& .MuiListItemText-secondary': {
+            maxWidth: '252px',
+            '& span:not(.file-size)': {
+              display: 'inline',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+            },
+          },
           '[data-testid=pending-item-text-primary]': {
             color: theme.palette.text.disabled,
           },
@@ -114,17 +128,9 @@ const StyledList = styled(List)((props) => {
             ...theme.typography.caption,
             '[data-testid=upload-status-label]': {
               color: theme.palette.success.main,
-              display: 'inline',
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
             },
             '[data-testid=failed-status-label]': {
               color: theme.palette.error.main,
-              display: 'inline',
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
             },
             '[data-testid=pending-item-text-secondary]': {
               color: theme.palette.text.disabled,
@@ -137,6 +143,9 @@ const StyledList = styled(List)((props) => {
               },
             },
           },
+        },
+        '&:hover .MuiListItemText-primary, &:hover .MuiListItemText-secondary': {
+          width: 'unset',
         },
         '.MuiListItemIcon-root': {
           '.MuiSvgIcon-root': {
@@ -359,10 +368,6 @@ const ProgressItems = (props: ProgressItemsProps) => {
         return (
           <React.Fragment key={`${queueItem.name}_${queueItem.timestamp}`}>
             <ListItem
-              onMouseEnter={() => { return setHover(`${queueItem.name}_${queueItem.timestamp}`); }}
-              onMouseLeave={() => { return setHover(null); }}
-              onFocus={() => { return setFocus(`${queueItem.name}_${queueItem.timestamp}`); }}
-              onBlur={() => { return setFocus(null); }}
               disablePadding
               sx={{ paddingLeft: (queueItem.type !== ProgressItemType.Folder && folderId === queueItem.collectionId) ? '8px' : '0px' }}
               hasBorder
@@ -370,6 +375,10 @@ const ProgressItems = (props: ProgressItemsProps) => {
               <ListItemButton
                 size={ListSizes.SMALL}
                 secondaryActionButton={renderHoverIcon(queueItem)}
+                onMouseEnter={() => { return setHover(`${queueItem.name}_${queueItem.timestamp}`); }}
+                onMouseLeave={() => { return setHover(null); }}
+                onFocus={() => { return setFocus(`${queueItem.name}_${queueItem.timestamp}`); }}
+                onBlur={() => { return setFocus(null); }}
               >
                 {queueItem.status === EnumUploadStatus.SUCCESS
                   ? (
@@ -396,14 +405,6 @@ const ProgressItems = (props: ProgressItemsProps) => {
                 {queueItem.status !== EnumUploadStatus.PENDING
                   ? (
                     <ListItemText
-                      sx={{
-                        '& .MuiListItemText-primary': {
-                          maxWidth: '240px',
-                          overflow: 'hidden',
-                          whiteSpace: 'nowrap',
-                          textOverflow: 'ellipsis',
-                        },
-                      }}
                       primary={(
                         <Tooltip title={queueItem.name} tooltipsize="small">
                           <span>{queueItem.name}</span>
@@ -412,12 +413,12 @@ const ProgressItems = (props: ProgressItemsProps) => {
                       secondary={(
                         <>
                           {queueItem.type !== 'folder' && (
-                            <span style={{ marginRight: '8px' }} data-testid="file-size">
+                            <span style={{ marginRight: '8px' }} data-testid="file-size" className="file-size">
                               {`${fileSizeValueConverter(queueItem.size)}`}
                             </span>
                           )}
                           {queueItem.status === EnumUploadStatus.SUCCESS && (
-                            <span data-testid="upload-status-label" style={{ maxWidth: '225px' }}>
+                            <span data-testid="upload-status-label">
                               {!queueItem.message ? translation?.successLabel : queueItem.message}
                             </span>
                           )}
@@ -429,7 +430,7 @@ const ProgressItems = (props: ProgressItemsProps) => {
                               <span
                                 data-testid="failed-status-label"
                                 style={{
-                                  maxWidth: showLearnMoreButton ? '165px' : '225px',
+                                  maxWidth: showLearnMoreButton ? '134px' : '252px',
                                 }}
                               >
                                 {!queueItem.message ? translation?.failureLabel : queueItem.message}
@@ -459,12 +460,7 @@ const ProgressItems = (props: ProgressItemsProps) => {
                     <ListItemText
                       primary={(
                         <Tooltip title={queueItem.name} tooltipsize="small">
-                          <span
-                            style={{
-                              maxWidth: '285px', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis',
-                            }}
-                            data-testid="pending-item-text-primary"
-                          >
+                          <span data-testid="pending-item-text-primary">
                             {queueItem.name}
                           </span>
                         </Tooltip>
@@ -472,7 +468,7 @@ const ProgressItems = (props: ProgressItemsProps) => {
                       secondary={(
                         <>
                           {queueItem.type !== 'folder' && (
-                            <span style={{ marginRight: '8px' }} data-testid="pending-item-text-secondary">
+                            <span style={{ marginRight: '8px' }} className="file-size" data-testid="pending-item-text-secondary">
                               {`${fileSizeValueConverter(queueItem.size)}`}
                             </span>
                           )}

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -15,6 +15,8 @@
 import { PopperPlacementType, Theme, SxProps } from '@mui/material';
 import React from 'react';
 import Button from '../../Button';
+import Menu from '../../Menu';
+import MenuItem from '../../Menu/MenuItem';
 
 export interface UnitSelectorProps {
   units: string[];
@@ -73,9 +75,11 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
         onClick={handleToggle}
         sx={{
           ...sx,
-          minWidth: 'auto',
-          cursor: 'pointer',
+          minWidth: '80px',
+          cursor: disabled ? 'default' : 'pointer',
           margin: 0,
+          textAlign: 'center',
+          padding: '0px',
         }}
         {...buttonProps}
         aria-controls={open ? 'unit-selector-menu' : undefined}
@@ -84,6 +88,64 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
       >
         {selectedUnit}
       </Button>
+
+      <Menu
+        id="unit-selector-menu"
+        anchorEl={anchorRef.current}
+        open={open}
+        onClose={handleClose}
+        size="small"
+        MenuListProps={{
+          'aria-labelledby': 'unit-selector-button',
+          dense: true,
+          autoFocusItem: open,
+        }}
+        anchorOrigin={{
+          vertical: placement.startsWith('bottom') ? 'bottom' : 'top',
+          // eslint-why-allow-ntesting
+          // eslint-disable-next-line no-nested-ternary
+          horizontal: placement.startsWith('start') ? 'left' : placement.endsWith('end') ? 'right' : 'center',
+        }}
+        transformOrigin={{
+          vertical: placement.startsWith('top') ? 'bottom' : 'top',
+          // eslint-why-allow-ntesting
+          // eslint-disable-next-line no-nested-ternary
+          horizontal: placement.endsWith('start') ? 'left' : placement.endsWith('end') ? 'right' : 'center',
+        }}
+        sx={{
+          '& .MuiMenu-paper': {
+            minWidth: '80px',
+            maxHeight: '136px',
+            marginTop: '2px',
+            padding: '0px',
+            boxShadow: (theme) => { return theme.shadows[2]; },
+          },
+          '& .MuiMenuItem-root': {
+            minHeight: '28px',
+            padding: '2px 10px',
+            justifyContent: 'end',
+          },
+        }}
+      >
+        {units.length > 0 ? (
+          units.map((unit) => {
+            return (
+              <MenuItem
+                key={unit}
+                size="small"
+                onClick={() => { return handleUnitSelect(unit); }}
+                selected={unit === selectedUnit}
+              >
+                {unit}
+              </MenuItem>
+            );
+          })
+        ) : (
+          <MenuItem size="small" disabled>
+            No units available
+          </MenuItem>
+        )}
+      </Menu>
     </div>
   );
 };

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -50,10 +50,6 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
   };
 
   const handleClose = (event: Event | React.SyntheticEvent) => {
-    if (anchorRef.current && anchorRef.current.contains(event.target as HTMLElement)) {
-      return;
-    }
-
     setOpen(false);
   };
 
@@ -61,7 +57,6 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
     if (unit !== selectedUnit) {
       onUnitChange(unit);
     }
-
     setOpen(false);
   };
 
@@ -78,6 +73,14 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
 
     return selectedUnit;
   }, [units, selectedUnit]);
+
+  const getDisplayValue = (unit: string): string => {
+    if (unit === 'Freeform') {
+      return 'ff';
+    }
+
+    return unit;
+  };
 
   React.useEffect(() => {
     if (open && anchorRef.current) {
@@ -123,7 +126,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
         aria-expanded={open ? 'true' : undefined}
         aria-haspopup="true"
       >
-        {validatedUnit}
+        {getDisplayValue(validatedUnit)}
       </Button>
 
       <Menu

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -124,6 +124,10 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
           '&.MuiButtonBase-root': {
             padding: '1px 4px !important',
           },
+          '.MuiInputBase-root:hover &': {
+            backgroundColor: (theme) => { return theme.palette.action.selectedOpacityModified; },
+            color: (theme) => { return theme.palette.action.selected; },
+          },
         }}
         {...buttonProps}
         aria-controls={open ? 'unit-selector-menu' : undefined}

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import Button from '../../Button';
 import Menu from '../../Menu';
 import MenuItem from '../../Menu/MenuItem';
+import Tooltip, { TooltipPlacement } from '../../Tooltip/Tooltip';
 
 export interface UnitSelectorProps {
   units: string[];
@@ -49,7 +50,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
     }
   };
 
-  const handleClose = (event: Event | React.SyntheticEvent) => {
+  const handleClose = (_event: Event | React.SyntheticEvent) => {
     setOpen(false);
   };
 
@@ -106,41 +107,49 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
 
   return (
     <div className={className} style={{ display: 'inline-flex' }}>
-      <Button
-        size="neutral"
-        variant="contained"
-        color={buttonActive ? 'secondary' : 'primary'}
-        disabled={disabled}
-        ref={anchorRef}
-        onClick={handleToggle}
-        sx={{
-          ...sx,
-          cursor: disabled ? 'default' : 'pointer',
-          margin: 0,
-          textAlign: 'center',
-          '&.MuiButtonBase-root': {
-            padding: '1px 4px !important',
-          },
-          '.MuiInputBase-root:hover &': {
-            backgroundColor: (theme) => { return theme.palette.action.selectedOpacityModified; },
-            color: (theme) => { return theme.palette.action.selected; },
-          },
-        }}
-        {...buttonProps}
-        aria-controls={open ? 'unit-selector-menu' : undefined}
-        aria-expanded={open ? 'true' : undefined}
-        aria-haspopup="true"
+      <Tooltip
+        title="No units available"
+        disableHoverListener={units.length > 0}
+        placement={TooltipPlacement.TOP}
       >
-        {getDisplayValue(validatedUnit)}
-      </Button>
+        <span>
+          <Button
+            size="neutral"
+            variant="contained"
+            color={buttonActive ? 'secondary' : 'primary'}
+            disabled={disabled || units.length === 0}
+            ref={anchorRef}
+            onClick={handleToggle}
+            sx={{
+              ...sx,
+              cursor: disabled ? 'default' : 'pointer',
+              margin: 0,
+              textAlign: 'center',
+              '&.MuiButtonBase-root': {
+                padding: '1px 4px !important',
+              },
+              '.MuiInputBase-root:hover &:not(.Mui-disabled)': {
+                backgroundColor: (theme) => { return theme.palette.action.selectedOpacityModified; },
+                color: (theme) => { return theme.palette.action.selected; },
+              },
+            }}
+            {...buttonProps}
+            aria-controls={open ? 'unit-selector-menu' : undefined}
+            aria-expanded={open ? 'true' : undefined}
+            aria-haspopup="true"
+          >
+            {units.length === 0 ? 'px' : getDisplayValue(validatedUnit)}
+          </Button>
+        </span>
+      </Tooltip>
 
       <Menu
+        id="unit-selector-menu"
         anchorEl={anchorRef.current}
         open={open}
         onClose={handleClose}
         size="small"
         MenuListProps={{
-          'aria-labelledby': 'unit-selector-button',
           dense: true,
           autoFocusItem: open,
         }}
@@ -168,24 +177,18 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
           },
         }}
       >
-        {units.length > 0 ? (
-          units.map((unit) => {
-            return (
-              <MenuItem
-                key={unit}
-                size="small"
-                onClick={() => { return handleUnitSelect(unit); }}
-                selected={unit === validatedUnit}
-              >
-                {unit}
-              </MenuItem>
-            );
-          })
-        ) : (
-          <MenuItem size="small" disabled>
-            No units available
-          </MenuItem>
-        )}
+        {units.map((unit) => {
+          return (
+            <MenuItem
+              key={unit}
+              size="small"
+              onClick={() => { return handleUnitSelect(unit); }}
+              selected={unit === validatedUnit}
+            >
+              {unit}
+            </MenuItem>
+          );
+        })}
       </Menu>
     </div>
   );

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -17,7 +17,6 @@ import React from 'react';
 import Button, { ButtonVariants } from '../../Button';
 import Menu, { MenuSizes } from '../../Menu';
 import MenuItem from '../../Menu/MenuItem';
-import Tooltip, { TooltipPlacement } from '../../Tooltip/Tooltip';
 
 export interface UnitSelectorProps {
   units: string[];
@@ -40,6 +39,10 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
   sx,
   buttonProps,
 }) => {
+  if (units.length === 0) {
+    return null;
+  }
+
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLButtonElement>(null);
   const [menuStyle, setMenuStyle] = React.useState<React.CSSProperties>({});
@@ -63,9 +66,6 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
   };
 
   const validatedUnit = React.useMemo(() => {
-    // If units array is empty, display 'px'
-    if (unitsIsEmpty) return 'px';
-
     const isValidUnit = units.includes(selectedUnit);
 
     // Return first unit in the array as fallback if selectedUnit is not in the units array
@@ -108,41 +108,33 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
 
   return (
     <div className={className} style={{ display: 'inline-flex' }}>
-      <Tooltip
-        title="No units available"
-        disableHoverListener={!unitsIsEmpty}
-        placement={TooltipPlacement.TOP}
+      <Button
+        size="neutral"
+        variant={ButtonVariants.CONTAINED}
+        color={buttonActive ? 'secondary' : 'primary'}
+        disabled={disabled || unitsIsEmpty}
+        ref={anchorRef}
+        onClick={handleToggle}
+        sx={{
+          ...sx,
+          cursor: disabled ? 'default' : 'pointer',
+          margin: 0,
+          textAlign: 'center',
+          '&.MuiButtonBase-root': {
+            padding: '1px 4px !important',
+          },
+          '.MuiInputBase-root:hover &:not(.Mui-disabled)': {
+            backgroundColor: (theme) => { return theme.palette.action.selectedOpacityModified; },
+            color: (theme) => { return theme.palette.action.selected; },
+          },
+        }}
+        {...buttonProps}
+        aria-controls={open ? 'unit-selector-menu' : undefined}
+        aria-expanded={open ? 'true' : undefined}
+        aria-haspopup="true"
       >
-        <span>
-          <Button
-            size="neutral"
-            variant={ButtonVariants.CONTAINED}
-            color={buttonActive ? 'secondary' : 'primary'}
-            disabled={disabled || unitsIsEmpty}
-            ref={anchorRef}
-            onClick={handleToggle}
-            sx={{
-              ...sx,
-              cursor: disabled ? 'default' : 'pointer',
-              margin: 0,
-              textAlign: 'center',
-              '&.MuiButtonBase-root': {
-                padding: '1px 4px !important',
-              },
-              '.MuiInputBase-root:hover &:not(.Mui-disabled)': {
-                backgroundColor: (theme) => { return theme.palette.action.selectedOpacityModified; },
-                color: (theme) => { return theme.palette.action.selected; },
-              },
-            }}
-            {...buttonProps}
-            aria-controls={open ? 'unit-selector-menu' : undefined}
-            aria-expanded={open ? 'true' : undefined}
-            aria-haspopup="true"
-          >
-            {getDisplayValue(validatedUnit)}
-          </Button>
-        </span>
-      </Tooltip>
+        {getDisplayValue(validatedUnit)}
+      </Button>
 
       <Menu
         id="unit-selector-menu"

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -64,6 +64,20 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
     setOpen(false);
   };
 
+  const validatedUnit = React.useMemo(() => {
+    // If units array is empty, display the selectedUnit
+    if (units.length === 0) return selectedUnit;
+
+    const isValidUnit = units.includes(selectedUnit);
+
+    // Return first unit in the array as fallback if selectedUnit is not in the units array
+    if (!isValidUnit) {
+      return units[0];
+    }
+
+    return selectedUnit;
+  }, [units, selectedUnit]);
+
   return (
     <div className={className} style={{ display: 'inline-flex' }}>
       <Button
@@ -86,7 +100,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
         aria-expanded={open ? 'true' : undefined}
         aria-haspopup="true"
       >
-        {selectedUnit}
+        {validatedUnit}
       </Button>
 
       <Menu

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -23,6 +23,7 @@ export interface UnitSelectorProps {
   selectedUnit: string;
   onUnitChange: (unit: string) => void;
   disabled?: boolean;
+  active?: boolean;
   className?: string;
   sx?: SxProps<Theme>;
   buttonProps?: React.ComponentProps<typeof Button>;
@@ -34,6 +35,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
   selectedUnit,
   onUnitChange,
   disabled = false,
+  active = false,
   className,
   sx,
   buttonProps,
@@ -82,6 +84,8 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
     return unit;
   };
 
+  const buttonActive = active || open;
+
   React.useEffect(() => {
     if (open && anchorRef.current) {
       // Find the closest TextField container
@@ -107,7 +111,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
       <Button
         size="neutral"
         variant="contained"
-        color="secondary"
+        color={buttonActive ? 'secondary' : 'primary'}
         disabled={disabled}
         ref={anchorRef}
         onClick={handleToggle}
@@ -153,7 +157,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
           '& .MuiMenu-paper': {
             minWidth: '80px',
             maxHeight: '136px',
-            marginTop: '4px',
+            marginTop: '6px',
             padding: '0px',
             boxShadow: (theme) => { return theme.shadows[2]; },
           },

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  * ======================================================================== */
-import { PopperPlacementType, Theme, SxProps } from '@mui/material';
+import { Theme, SxProps } from '@mui/material';
 import React from 'react';
 import Button from '../../Button';
 import Menu from '../../Menu';
@@ -27,7 +27,6 @@ export interface UnitSelectorProps {
   className?: string;
   sx?: SxProps<Theme>;
   buttonProps?: React.ComponentProps<typeof Button>;
-  placement?: PopperPlacementType;
 }
 
 const UnitSelector: React.FC<UnitSelectorProps> = ({
@@ -39,7 +38,6 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
   className,
   sx,
   buttonProps,
-  placement = 'bottom-start',
 }) => {
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLButtonElement>(null);
@@ -117,7 +115,6 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
         onClick={handleToggle}
         sx={{
           ...sx,
-          minWidth: '80px',
           cursor: disabled ? 'default' : 'pointer',
           margin: 0,
           textAlign: 'center',
@@ -138,7 +135,6 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
       </Button>
 
       <Menu
-        id="unit-selector-menu"
         anchorEl={anchorRef.current}
         open={open}
         onClose={handleClose}
@@ -159,7 +155,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
         sx={{
           ...menuStyle,
           '& .MuiMenu-paper': {
-            minWidth: '80px',
+            minWidth: '72px',
             maxHeight: '136px',
             marginTop: '6px',
             padding: '0px',

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -15,7 +15,7 @@
 import { Theme, SxProps } from '@mui/material';
 import React from 'react';
 import Button, { ButtonVariants } from '../../Button';
-import Menu from '../../Menu';
+import Menu, { MenuSizes } from '../../Menu';
 import MenuItem from '../../Menu/MenuItem';
 import Tooltip, { TooltipPlacement } from '../../Tooltip/Tooltip';
 
@@ -149,7 +149,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
         anchorEl={anchorRef.current}
         open={open}
         onClose={handleClose}
-        size="small"
+        size={MenuSizes.SMALL}
         MenuListProps={{
           dense: true,
           autoFocusItem: open,
@@ -182,7 +182,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
           return (
             <MenuItem
               key={unit}
-              size="small"
+              size={MenuSizes.SMALL}
               onClick={() => { return handleUnitSelect(unit); }}
               selected={unit === validatedUnit}
             >

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -41,6 +41,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
 }) => {
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLButtonElement>(null);
+  const [menuStyle, setMenuStyle] = React.useState<React.CSSProperties>({});
 
   const handleToggle = () => {
     if (!disabled) {
@@ -78,6 +79,26 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
     return selectedUnit;
   }, [units, selectedUnit]);
 
+  React.useEffect(() => {
+    if (open && anchorRef.current) {
+      // Find the closest TextField container
+      const textFieldEl = anchorRef.current.closest('.MuiOutlinedInput-root');
+
+      if (textFieldEl) {
+        // Get the right edge position of the TextField
+        const textFieldRect = textFieldEl.getBoundingClientRect();
+        const buttonRect = anchorRef.current.getBoundingClientRect();
+
+        // Calculate the offset
+        const offsetX = textFieldRect.right - buttonRect.right;
+
+        setMenuStyle({
+          marginLeft: `${offsetX}px`,
+        });
+      }
+    }
+  }, [open]);
+
   return (
     <div className={className} style={{ display: 'inline-flex' }}>
       <Button
@@ -93,7 +114,9 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
           cursor: disabled ? 'default' : 'pointer',
           margin: 0,
           textAlign: 'center',
-          padding: '0px',
+          '&.MuiButtonBase-root': {
+            padding: '1px 4px !important',
+          },
         }}
         {...buttonProps}
         aria-controls={open ? 'unit-selector-menu' : undefined}
@@ -115,22 +138,19 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
           autoFocusItem: open,
         }}
         anchorOrigin={{
-          vertical: placement.startsWith('bottom') ? 'bottom' : 'top',
-          // eslint-why-allow-ntesting
-          // eslint-disable-next-line no-nested-ternary
-          horizontal: placement.startsWith('start') ? 'left' : placement.endsWith('end') ? 'right' : 'center',
+          vertical: 'bottom',
+          horizontal: 'right',
         }}
         transformOrigin={{
-          vertical: placement.startsWith('top') ? 'bottom' : 'top',
-          // eslint-why-allow-ntesting
-          // eslint-disable-next-line no-nested-ternary
-          horizontal: placement.endsWith('start') ? 'left' : placement.endsWith('end') ? 'right' : 'center',
+          vertical: 'top',
+          horizontal: 'right',
         }}
         sx={{
+          ...menuStyle,
           '& .MuiMenu-paper': {
             minWidth: '80px',
             maxHeight: '136px',
-            marginTop: '2px',
+            marginTop: '4px',
             padding: '0px',
             boxShadow: (theme) => { return theme.shadows[2]; },
           },
@@ -148,7 +168,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
                 key={unit}
                 size="small"
                 onClick={() => { return handleUnitSelect(unit); }}
-                selected={unit === selectedUnit}
+                selected={unit === validatedUnit}
               >
                 {unit}
               </MenuItem>

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -62,8 +62,8 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
   };
 
   const validatedUnit = React.useMemo(() => {
-    // If units array is empty, display the selectedUnit
-    if (units.length === 0) return selectedUnit;
+    // If units array is empty, display 'px'
+    if (units.length === 0) return 'px';
 
     const isValidUnit = units.includes(selectedUnit);
 
@@ -138,7 +138,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
             aria-expanded={open ? 'true' : undefined}
             aria-haspopup="true"
           >
-            {units.length === 0 ? 'px' : getDisplayValue(validatedUnit)}
+            {getDisplayValue(validatedUnit)}
           </Button>
         </span>
       </Tooltip>

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -1,0 +1,91 @@
+/* ======================================================================== *
+ * Copyright 2025 HCL America Inc.                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ * http://www.apache.org/licenses/LICENSE-2.0                               *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ * ======================================================================== */
+import { PopperPlacementType, Theme, SxProps } from '@mui/material';
+import React from 'react';
+import Button from '../../Button';
+
+export interface UnitSelectorProps {
+  units: string[];
+  selectedUnit: string;
+  onUnitChange: (unit: string) => void;
+  disabled?: boolean;
+  className?: string;
+  sx?: SxProps<Theme>;
+  buttonProps?: React.ComponentProps<typeof Button>;
+  placement?: PopperPlacementType;
+}
+
+const UnitSelector: React.FC<UnitSelectorProps> = ({
+  units = [],
+  selectedUnit,
+  onUnitChange,
+  disabled = false,
+  className,
+  sx,
+  buttonProps,
+  placement = 'bottom-start',
+}) => {
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef<HTMLButtonElement>(null);
+
+  const handleToggle = () => {
+    if (!disabled) {
+      setOpen((prevOpen) => { return !prevOpen; });
+    }
+  };
+
+  const handleClose = (event: Event | React.SyntheticEvent) => {
+    if (anchorRef.current && anchorRef.current.contains(event.target as HTMLElement)) {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  const handleUnitSelect = (unit: string) => {
+    if (unit !== selectedUnit) {
+      onUnitChange(unit);
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <div className={className} style={{ display: 'inline-flex' }}>
+      <Button
+        size="neutral"
+        variant="contained"
+        color="secondary"
+        disabled={disabled}
+        ref={anchorRef}
+        onClick={handleToggle}
+        sx={{
+          ...sx,
+          minWidth: 'auto',
+          cursor: 'pointer',
+          margin: 0,
+        }}
+        {...buttonProps}
+        aria-controls={open ? 'unit-selector-menu' : undefined}
+        aria-expanded={open ? 'true' : undefined}
+        aria-haspopup="true"
+      >
+        {selectedUnit}
+      </Button>
+    </div>
+  );
+};
+
+export default UnitSelector;

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -46,7 +46,6 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLButtonElement>(null);
   const [menuStyle, setMenuStyle] = React.useState<React.CSSProperties>({});
-  const unitsIsEmpty = units.length === 0;
 
   const handleToggle = () => {
     if (!disabled) {
@@ -112,7 +111,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
         size="neutral"
         variant={ButtonVariants.CONTAINED}
         color={buttonActive ? 'secondary' : 'primary'}
-        disabled={disabled || unitsIsEmpty}
+        disabled={disabled}
         ref={anchorRef}
         onClick={handleToggle}
         sx={{

--- a/src/prerequisite_components/UnitSelector/UnitSelector.tsx
+++ b/src/prerequisite_components/UnitSelector/UnitSelector.tsx
@@ -14,7 +14,7 @@
  * ======================================================================== */
 import { Theme, SxProps } from '@mui/material';
 import React from 'react';
-import Button from '../../Button';
+import Button, { ButtonVariants } from '../../Button';
 import Menu from '../../Menu';
 import MenuItem from '../../Menu/MenuItem';
 import Tooltip, { TooltipPlacement } from '../../Tooltip/Tooltip';
@@ -43,6 +43,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLButtonElement>(null);
   const [menuStyle, setMenuStyle] = React.useState<React.CSSProperties>({});
+  const unitsIsEmpty = units.length === 0;
 
   const handleToggle = () => {
     if (!disabled) {
@@ -63,7 +64,7 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
 
   const validatedUnit = React.useMemo(() => {
     // If units array is empty, display 'px'
-    if (units.length === 0) return 'px';
+    if (unitsIsEmpty) return 'px';
 
     const isValidUnit = units.includes(selectedUnit);
 
@@ -109,15 +110,15 @@ const UnitSelector: React.FC<UnitSelectorProps> = ({
     <div className={className} style={{ display: 'inline-flex' }}>
       <Tooltip
         title="No units available"
-        disableHoverListener={units.length > 0}
+        disableHoverListener={!unitsIsEmpty}
         placement={TooltipPlacement.TOP}
       >
         <span>
           <Button
             size="neutral"
-            variant="contained"
+            variant={ButtonVariants.CONTAINED}
             color={buttonActive ? 'secondary' : 'primary'}
-            disabled={disabled || units.length === 0}
+            disabled={disabled || unitsIsEmpty}
             ref={anchorRef}
             onClick={handleToggle}
             sx={{

--- a/src/prerequisite_components/UnitSelector/index.ts
+++ b/src/prerequisite_components/UnitSelector/index.ts
@@ -1,0 +1,18 @@
+/* ======================================================================== *
+ * Copyright 2025 HCL America Inc.                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ * http://www.apache.org/licenses/LICENSE-2.0                               *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ * ======================================================================== */
+import UnitSelector from './UnitSelector';
+
+export default UnitSelector;
+export * from './UnitSelector';


### PR DESCRIPTION
This PR covers the following changes:

- Created a UnitSelector component under prerequisite_components
- Apply this component to the InputProps endAdornment of TextField
- Create examples in TextField stories

Design link: https://www.figma.com/design/IQYr8v2tFkJDPcx31sJCkH/Presentation-Designer?node-id=8134-13325&t=tkC8mr2zpg984ERt-0