### PR TITLE
[WCAG 2.1 2.4.3] Date picker icon shows on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixing all Textfield based components helpertext position when text direction is RTL. (Textfield based components are DatePicker, Autocomplete, SelectSingle, SelectMultiple)
 - Fixed the issue where the 'Learn more' button shifted when hovering over the list of progress items in the `ProgressBar` component.
 - Fixing the focus issue when there are more than one date picker that are used side by side.
+- Fixing the focus issue when after selecting a date the focus remains there on the input field and date picker icon.
 
 ### Changed
 

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -261,6 +261,12 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
     };
     return textFieldProps;
   };
+  const handleClose = () => {
+    setTimeout(() => {
+      const activeElement = document.activeElement as HTMLButtonElement;
+      activeElement.blur();
+    }, 100);
+  };
 
   return (
     <MuiDatePicker
@@ -269,6 +275,7 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
       autoFocus={false}
       onOpen={focusDialog}
       dayOfWeekFormatter={(day) => { return day; }}
+      onClose={handleClose}
       PaperProps={{
         sx: (theme) => { return getDatePickerStyle(theme, customStyles); },
       }}


### PR DESCRIPTION
Date picker icon button shows on focus after selecting a date on mouse navigation.
https://jira.cwp.pnp-hcl.com/browse/DXQ-30425