### PR TITLE
Fix a11y issue - NVDA doesn't read label for Autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Fixed focus handling on open of `DatePicker` popper to address accessibility issues
+- Fixed screen reader accessibility issue with the `label` in `Autocomplete` component
 
 ### Changed
 

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -163,6 +163,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
             textFieldArgs.inputProps = {
               'aria-describedby': props.error ? undefined : helperTextId,
               'aria-errormessage': props.error ? helperTextId : undefined,
+              'aria-labelledby': props.id ? `${props.id}-label` : undefined,
               ...textFieldArgs.inputProps,
               ...inputPropsValue,
             };


### PR DESCRIPTION
**Issue:** the screen reader does not narrate the label of the Autocomplete input field

![image](https://github.com/user-attachments/assets/5f1e8ff4-93cb-48f0-92e6-526dd8981aeb)


**Fix:** Added `aria-labelledby` to the inputProps of the TextField in the Autocomplete component to properly associate the input with its label for screen readers.
![image](https://github.com/user-attachments/assets/a2c070af-ef41-4e70-8375-78b7c25a8d00)
