### PR TITLE
Fix Pagination issue with Autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed focus handling on open of `DatePicker` popper to address accessibility issues
 - Fixed screen reader accessibility issue with the `label` in `Autocomplete` component
 - Fixed position of UnitSelector button and menu when theme direction is RTL
+- Fixed pagination wrong rendered page number issue by removing textfield input control from `Autocomplete`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fixed focus handling on open of `DatePicker` popper to address accessibility issues
 - Fixed screen reader accessibility issue with the `label` in `Autocomplete` component
 - Fixed position of UnitSelector button and menu when theme direction is RTL
-- Fixed pagination wrong rendered page number issue by removing textfield input control from `Autocomplete`
+- Fixed wrong rendered page number issue in pagination by removing conflict in value and inputPropsValue in `Autocomplete`
 
 ### Changed
 

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -159,7 +159,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
               value: props.value,
             };
             const tooltipTitle = isValueOverFlowing ? textfieldRef.current?.value || '' : '';
-            const inputPropsValue = props.renderOption ? {} : { value: props.value };
+            const inputPropsValue = props.renderOption ? {} : undefined;
             textFieldArgs.inputProps = {
               'aria-describedby': props.error ? undefined : helperTextId,
               'aria-errormessage': props.error ? helperTextId : undefined,


### PR DESCRIPTION
Fixed pagination wrong rendered page number issue by removing textfield input control from `Autocomplete`

- autocomplete when used in pagination component: page 1 should show page 1, not page 0
- autocomplete when used standalone or any other use case: value of textfield should be controlled by renderInput (textfieldArgs.value, not textfieldArgs.inputPropsValue)

Fixed:

https://github.com/user-attachments/assets/e1705ca7-1729-4382-9fb1-d978142a606a


https://github.com/user-attachments/assets/95799242-9874-4667-a7ac-b19df7b3a12f



The Bug:

<img width="1054" alt="Screenshot 2025-04-30 at 7 46 45 PM" src="https://github.com/user-attachments/assets/9dada7a3-7bfd-4be2-86e3-6193df1ecece" />
