### PR TITLE
undo inputPropsValue arg totally - makes freesolo typing on MultiSelectChip impossible (based on Autocomplete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - Fixed focus handling on open of `DatePicker` popper to address accessibility issues
 - Fixed screen reader accessibility issue with the `label` in `Autocomplete` component
 - Fixed position of UnitSelector button and menu when theme direction is RTL
-- Fixed wrong rendered page number issue in pagination by removing conflict in value and inputPropsValue in `Autocomplete`
+- Fixed wrong rendered page number issue in Pagination by removing use of inputPropsValue in `Autocomplete`
+- Fixed cannot type freesolo in MultiSelectChip by removing use of inputPropsValue in `Autocomplete`
 
 ### Changed
 

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -159,13 +159,11 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
               value: props.value,
             };
             const tooltipTitle = isValueOverFlowing ? textfieldRef.current?.value || '' : '';
-            const inputPropsValue = props.renderOption ? {} : undefined;
             textFieldArgs.inputProps = {
               'aria-describedby': props.error ? undefined : helperTextId,
               'aria-errormessage': props.error ? helperTextId : undefined,
               'aria-labelledby': props.id ? `${props.id}-label` : undefined,
               ...textFieldArgs.inputProps,
-              ...inputPropsValue,
             };
             return (
               <Tooltip title={tooltipTitle} tooltipsize="small">


### PR DESCRIPTION
Should allow typing on MultiSelectChip again

See bug video here: https://jira.cwp.pnp-hcl.com/browse/DXQ-43317

Undo this fix: https://github.com/HCL-TECH-SOFTWARE/enchanted-react-components/pull/147

