### PR TITLE
Add tooltip for close button and fix extra space in in Popper component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 - Fixed position of UnitSelector button and menu when theme direction is RTL
 - Fixed wrong rendered page number issue in Pagination by removing use of inputPropsValue in `Autocomplete`
 - Fixed cannot type freesolo in MultiSelectChip by removing use of inputPropsValue in `Autocomplete`
+- Fixed extra space below the `Popper` title
 
 ### Changed
+- Added tooltip to the close button in `Popper` component
 
 ### Breaking changes
 

--- a/src/Popper/Popper.tsx
+++ b/src/Popper/Popper.tsx
@@ -24,6 +24,7 @@ import PopperTitle from './PopperTitle';
 import PopperContent from './PopperContent';
 import { TYPOGRAPHY } from '../theme';
 import Divider, { DividerTypes } from '../Divider';
+import Tooltip from '../Tooltip';
 
 export enum PopperTestIds {
   POPPER_TITLE = 'popperTitle',
@@ -37,6 +38,7 @@ export type PopperProps = MuiPopperProps & {
   subHeaderChildren?: React.ReactNode,
   onClose: Function,
   hideSubHeader?: boolean,
+  closeIconTooltip?: string,
 };
 
 const Popper = ({ ...props }: PopperProps) => {
@@ -83,13 +85,15 @@ const Popper = ({ ...props }: PopperProps) => {
           <Grid container>
             <Grid item>
               <Grid>{headerChildren}</Grid>
-              <IconButton
-                aria-label={PopperTestIds.POPPER_TITLE}
-                onClick={(e) => { onClose(e, 'backdropClick'); }}
-                data-testid={PopperTestIds.POPPER_CLOSE_ICON}
-              >
-                <CloseIcon />
-              </IconButton>
+              <Tooltip title={props.closeIconTooltip || ''}>
+                <IconButton
+                  aria-label={props.closeIconTooltip ? props. closeIconTooltip : PopperTestIds.POPPER_TITLE}
+                  onClick={(e) => { onClose(e, 'backdropClick'); }}
+                  data-testid={PopperTestIds.POPPER_CLOSE_ICON}
+                >
+                  <CloseIcon />
+                </IconButton>
+              </Tooltip>
             </Grid>
           </Grid>
         </PopperTitle>

--- a/src/Popper/Popper.tsx
+++ b/src/Popper/Popper.tsx
@@ -82,20 +82,16 @@ const Popper = ({ ...props }: PopperProps) => {
       {(headerChildren)
         && (
         <PopperTitle data-testid={PopperTestIds.POPPER_TITLE}>
-          <Grid container>
-            <Grid item>
-              <Grid>{headerChildren}</Grid>
-              <Tooltip title={props.closeIconTooltip || ''}>
-                <IconButton
-                  aria-label={props.closeIconTooltip ? props. closeIconTooltip : PopperTestIds.POPPER_TITLE}
-                  onClick={(e) => { onClose(e, 'backdropClick'); }}
-                  data-testid={PopperTestIds.POPPER_CLOSE_ICON}
-                >
-                  <CloseIcon />
-                </IconButton>
-              </Tooltip>
-            </Grid>
-          </Grid>
+          <Grid>{headerChildren}</Grid>
+          <Tooltip title={props.closeIconTooltip || ''}>
+            <IconButton
+              aria-label={props.closeIconTooltip ? props. closeIconTooltip : PopperTestIds.POPPER_TITLE}
+              onClick={(e) => { onClose(e, 'backdropClick'); }}
+              data-testid={PopperTestIds.POPPER_CLOSE_ICON}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Tooltip>
         </PopperTitle>
         )}
       {(!hideSubHeader)

--- a/src/Popper/Popper.tsx
+++ b/src/Popper/Popper.tsx
@@ -85,7 +85,7 @@ const Popper = ({ ...props }: PopperProps) => {
           <Grid>{headerChildren}</Grid>
           <Tooltip title={props.closeIconTooltip || ''}>
             <IconButton
-              aria-label={props.closeIconTooltip ? props. closeIconTooltip : PopperTestIds.POPPER_TITLE}
+              aria-label={props.closeIconTooltip ? props.closeIconTooltip : PopperTestIds.POPPER_TITLE}
               onClick={(e) => { onClose(e, 'backdropClick'); }}
               data-testid={PopperTestIds.POPPER_CLOSE_ICON}
             >


### PR DESCRIPTION
- Added tooltip for close button in Popper component
- Fixed extra space below the popper title

Before:
<img width="924" alt="image" src="https://github.com/user-attachments/assets/f3f2b9aa-c3d7-440c-ad95-9ad664abade7" />

After:
<img width="860" alt="image" src="https://github.com/user-attachments/assets/cb190b92-834d-42da-b6e7-fd38d46b9b9f" />
