### PR TITLE
Progress bar css  fix for cancelled items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - Fixed the disabled state CSS for the `cancel` All button, removed the `cancel all` button from the ProgressBar subheader, and removed focus from cancelled items in the ProgressBar.
 - Fixed tab indicator not updating when tabValue changes in `Tabs` component
+- Fixed the CSS for cancelled items in progress bar item list on hover.
 
 ### Changed
 

--- a/src/List/ListItemButton.tsx
+++ b/src/List/ListItemButton.tsx
@@ -67,17 +67,6 @@ export const getMuiListItemButtonThemeOverrides = (): Components<Omit<Theme, 'co
           };
 
           return {
-            '&.MuiListItemButton-root.disabled-hover': {
-              pointerEvents: 'none',
-              backgroundColor: 'transparent',
-              '&:hover': {
-                backgroundColor: 'transparent',
-              },
-              '&.Mui-focusVisible': {
-                boxShadow: 'none',
-                backgroundColor: 'transparent',
-              },
-            },
             '&.MuiListItemButton-root': {
               ...listItemStyle,
               '.MuiListItemIcon-root': {
@@ -107,6 +96,10 @@ export const getMuiListItemButtonThemeOverrides = (): Components<Omit<Theme, 'co
             },
             '&:hover': {
               backgroundColor: theme.palette.action.hover,
+            },
+            '&.MuiListItemButton-root.disabled-hover': {
+              pointerEvents: 'none',
+              backgroundColor: 'transparent',
             },
             '&.Mui-focusVisible': {
               backgroundColor: 'transparent',
@@ -172,12 +165,13 @@ export const getMuiListItemButtonThemeOverrides = (): Components<Omit<Theme, 'co
 const ListItemButton = ({ disabledHover, ...props }: ListItemButtonProps) => {
   const theme = useTheme();
   const { secondaryActionButton, ...restProps } = props;
-
+  const composedClassName = [props.className, disabledHover ? 'disabled-hover' : ''].filter(Boolean).join(' ');
   return (
     <MuiListItemButton
       {...restProps}
-      className={`${disabledHover ? 'disabled-hover' : ''} ${props.className || ''}`}
+      className={composedClassName}
       tabIndex={disabledHover ? -1 : props.tabIndex}
+      aria-disabled={disabledHover ? 'true' : undefined}
     >
       {props.children}
       {secondaryActionButton


### PR DESCRIPTION
This PR contains the updated CSS to remove pointer and focus on Hover from a cancelled item in progressbar items list.

Jira: https://jira.cwp.pnp-hcl.com/browse/DXQ-43488

[Enchanted UI PR](https://github.com/nidhinrajr/enchanted-ui/pull/12)