### PR TITLE
Ensure cancelled items ignore hover and click events - Progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed the CSS for cancelled items in progress bar item list on hover.
 - Fixed ref forwarding support for the List component to allow parent components to access the underlying DOM element.
 - Fixed placeholder color for TextField component when multiline prop is passed.
+- Fixed Progress bar cancelled item on hover css
 
 ### Changed
 

--- a/src/List/ListItemButton.tsx
+++ b/src/List/ListItemButton.tsx
@@ -98,8 +98,11 @@ export const getMuiListItemButtonThemeOverrides = (): Components<Omit<Theme, 'co
               backgroundColor: theme.palette.action.hover,
             },
             '&.MuiListItemButton-root.disabled-hover': {
-              pointerEvents: 'none',
-              backgroundColor: 'transparent',
+              pointerEvents: 'none !important',
+              backgroundColor: 'transparent !important',
+              '&:hover': {
+                backgroundColor: 'transparent !important',
+              },
             },
             '&.Mui-focusVisible': {
               backgroundColor: 'transparent',

--- a/src/composite_components/ProgressBar/ProgressItems.tsx
+++ b/src/composite_components/ProgressBar/ProgressItems.tsx
@@ -163,6 +163,13 @@ const StyledList = styled(List)((props) => {
           },
         },
       },
+      '.MuiListItemButton-root.disabled-hover': {
+        pointerEvents: 'none !important',
+        backgroundColor: 'transparent !important',
+        '&:hover': {
+          backgroundColor: 'transparent !important',
+        },
+      },
     },
   });
 });


### PR DESCRIPTION
Fixed CSS override issue. disable hover CSS was working fine in storybook but in DAM due to override issue the disabled hover css was not reflecting correctly. HEnce fixed the issue. Below are the verification details.

StoryBook : 
<img width="1724" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/2a82aef6-c517-45f9-88e0-795d489dcebf" />

npm run build, replaced dist folder from hcl-software/enchanted-react-components into Media library

In DAM, did Make install then Import progressbar from enchanted-react component (only this change required).

Verified in DAM, CSS is reflecting. 
<img width="1728" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/e1508366-560d-41d1-989c-a28b20aa2d7b" />

[enchanted-ui PR (**merged**)](https://github.com/nidhinrajr/enchanted-ui/pull/13)

Verfied the changes in DAM locally and in native-kube as well post enchanted-ui PR merged. 
[Media library PR with native kube details and verification](https://git.cwp.pnp-hcl.com/websphere-portal-incubator/media-library/pull/3753)



