### PR TITLE
fix: tooltip in progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed placeholder color for TextField component when multiline prop is passed.
 - Fixed Progress bar cancelled item on hover css
 - Fixed Tooltip on Tab hover by forwarding ref
+- Fixed tooltip overflow on progress bars during hover and scroll of uploaded items.
 
 ### Changed
 

--- a/src/composite_components/ProgressBar/ProgressItems.tsx
+++ b/src/composite_components/ProgressBar/ProgressItems.tsx
@@ -414,7 +414,13 @@ const ProgressItems = (props: ProgressItemsProps) => {
                   ? (
                     <ListItemText
                       primary={(
-                        <Tooltip title={queueItem.name} tooltipsize="small">
+                        <Tooltip
+                          title={queueItem.name}
+                          tooltipsize="small"
+                          PopperProps={{
+                            disablePortal: true,
+                          }}
+                        >
                           <span>{queueItem.name}</span>
                         </Tooltip>
                       )}


### PR DESCRIPTION
This PR resolved the issue where tooltips on progress bars would float outside their parent container when hovering over and scrolling through uploaded items.