### PR TITLE
Update ref type to paper component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed Tooltip on Tab hover by forwarding ref
 - Fixed tooltip overflow on progress bars during hover and scroll of uploaded items.
 - Fixed accordion to apply square prop
+- Fixed ref forwarding support for the paper component
 
 ### Changed
 

--- a/src/Paper/Paper.tsx
+++ b/src/Paper/Paper.tsx
@@ -17,9 +17,11 @@ import React from 'react';
 import MuiPaper, { PaperProps } from '@mui/material/Paper';
 import { Components, Theme } from '@mui/material';
 
-const Paper = ({ ...props }: PaperProps) => {
-  return <MuiPaper {...props} />;
-};
+const Paper = React.forwardRef<HTMLUListElement, PaperProps> (
+  (props: PaperProps, ref: React.Ref<HTMLUListElement>) => {
+    return <MuiPaper ref={ref} {...props} />;
+  }
+);
 
 declare module '@mui/material/Paper' {
   interface PaperPropsVariantOverrides {


### PR DESCRIPTION
Reference Issue : 
https://github.com/HCL-TECH-SOFTWARE/enchanted-react-components/issues/266

**Steps to reproduce
Steps:**

import Paper element from enchanted MUI
try to assign any ref to this Paper element
try referring this ref after the paper element, the ref is always null, if we use ref on Paper element imported from MUI, it works as expected.
Current behavior
Ref pointed to Paper element from enchanted library is always null.

**Expected behavior**
Ref should be updated with Paper element reference.

**Context**
We need to create a ref for paper element so that we can highlight this paper element when this is in focus to support accessibility. with current enchanted component we are unable to pass a valid ref to Paper element.

