### PR TITLE
DXQ-44750-Fixing_CancelAll_to_be_inSingleLine

### DIFF
--- a/src/composite_components/ProgressBar/ProgressHeader.tsx
+++ b/src/composite_components/ProgressBar/ProgressHeader.tsx
@@ -235,6 +235,12 @@ const ProgressHeader = (props: progressHeaderProps) => {
                 if (cancelAll) cancelAll();
               }}
               disabled={isCancelAllDisabled}
+              sx={{
+              whiteSpace: 'nowrap',
+              maxWidth: '121px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              }}
             >
               {stringLiterals.cancelAllLabel}
             </Button>


### PR DESCRIPTION
The text on the CancelAll button was sometimes wrapping to two lines due to alignment

Fix: Adjusted the button alignment and styling to ensure the text remains on a single line consistently