### PR TITLE
DXQ-41961-enable-to-read-the-information-icon-on-the-Content-Element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Added the `togglePanelLabel` props in Panel and PanelTabs components
+- Added a new prop - enableHelpHoverEffect - to improve accessibility of help icon in input field components (Textfield, Select Single/Multiple, Autocomplete, MultipleSelectChip, DatePicker).
 
 ### Added
 - Added tooltip on hover for uploaded text in progressBar header.
@@ -27,7 +28,6 @@
 - Fixed tooltip overflow on progress bars during hover and scroll of uploaded items.
 - Fixed accordion to apply square prop
 - Fixed ref forwarding support for the paper component
-- Added a new prop - enableHelpHoverEffect - to improve accessibility of help icon in input field components (Textfield, Select Single/Multiple, Autocomplete, MultipleSelectChip, DatePicker).
 
 ### Changed
 - Upgraded dependency to Enchanted Icons v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed tooltip overflow on progress bars during hover and scroll of uploaded items.
 - Fixed accordion to apply square prop
 - Fixed ref forwarding support for the paper component
+- Fixed the tab and added a new prop to enable the hover effect on the help icon
 
 ### Changed
 - Upgraded dependency to Enchanted Icons v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Fixed tooltip overflow on progress bars during hover and scroll of uploaded items.
 - Fixed accordion to apply square prop
 - Fixed ref forwarding support for the paper component
-- Fixed the tab and added a new prop to enable the hover effect on the help icon
+- Fixed the accessibility of help icon and added a new prop to enable a hover effect on it
 
 ### Changed
 - Upgraded dependency to Enchanted Icons v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Fixed tooltip overflow on progress bars during hover and scroll of uploaded items.
 - Fixed accordion to apply square prop
 - Fixed ref forwarding support for the paper component
-- Fixed the accessibility of help icon and added a new prop to enable a hover effect on it
+- Added a new prop - enableHelpHoverEffect - to improve accessibility of help icon in input field components (Textfield, Select Single/Multiple, Autocomplete, MultipleSelectChip, DatePicker).
 
 ### Changed
 - Upgraded dependency to Enchanted Icons v1.5.0

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -165,7 +165,7 @@ export default {
       control: false,
       description: 'actionProps of the Action Buttons',
     },
-    iconHoverEffect: {
+    enableHoverEffect: {
       control: 'boolean',
       table: {
         defaultValue: {
@@ -263,7 +263,7 @@ export const ExampleAutocomplete = {
     autoFocus: false,
     hiddenLabel: false,
     nonEdit: false,
-    iconHoverEffect: false,
+    enableHoverEffect: false,
     actionProps: [
       // In component, this will render only max 2 action links at least until Figma design for action link variants is finalized
       {

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -52,7 +52,7 @@ export default {
       description:
         'Tooltip text hovering on ? mark for Autocomplete component',
     },
-    enableHoverEffect: {
+    enableHelpHoverEffect: {
       control: 'boolean',
       table: {
         defaultValue: {
@@ -263,7 +263,7 @@ export const ExampleAutocomplete = {
     autoFocus: false,
     hiddenLabel: false,
     nonEdit: false,
-    enableHoverEffect: false,
+    enableHelpHoverEffect: false,
     actionProps: [
       // In component, this will render only max 2 action links at least until Figma design for action link variants is finalized
       {

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -52,6 +52,15 @@ export default {
       description:
         'Tooltip text hovering on ? mark for Autocomplete component',
     },
+    enableHoverEffect: {
+      control: 'boolean',
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+      description: 'If true, the helper icon displays a gray background when hovered.',
+    },
     tooltipPlacement: {
       description: 'Tooltip placement for ? mark for Autocomplete component.',
       options: [
@@ -164,15 +173,6 @@ export default {
     actionProps: {
       control: false,
       description: 'actionProps of the Action Buttons',
-    },
-    enableHoverEffect: {
-      control: 'boolean',
-      table: {
-        defaultValue: {
-          summary: false,
-        },
-      },
-      description: 'If `true`, the helper icon will have a gray background on hover.',
     },
     clearIcon: {
       control: false,

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -1,5 +1,5 @@
 /* ======================================================================== *
- * Copyright 2024 HCL America Inc.                                          *
+ * Copyright 2024, 2025 HCL America Inc.                                    *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
  * You may obtain a copy of the License at                                  *
@@ -165,6 +165,15 @@ export default {
       control: false,
       description: 'actionProps of the Action Buttons',
     },
+    iconHoverEffect: {
+      control: 'boolean',
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+      description: 'If `true`, the helper icon will have a gray background on hover.',
+    },
     clearIcon: {
       control: false,
       description: 'clear Icon of the Autocomplete component.',
@@ -254,6 +263,7 @@ export const ExampleAutocomplete = {
     autoFocus: false,
     hiddenLabel: false,
     nonEdit: false,
+    iconHoverEffect: false,
     actionProps: [
       // In component, this will render only max 2 action links at least until Figma design for action link variants is finalized
       {

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -38,7 +38,7 @@ export interface AutocompleteProps<T, Multiple, DisableClearable, FreeSolo> exte
   actionProps?: ActionProps[];
   nonEdit?: boolean;
   helperText?: string;
-  enableHoverEffect?: boolean;
+  enableHelpHoverEffect?: boolean;
   helperIconTooltip?: string;
   tooltipPlacement?: TooltipPlacement;
   label?: string;
@@ -93,7 +93,7 @@ DisableClearable extends boolean | undefined = undefined, FreeSolo extends boole
     hiddenLabel: props.hiddenLabel,
     isFocus,
     fullWidth: props.fullWidth,
-    enableHoverEffect: props.enableHoverEffect,
+    enableHelpHoverEffect: props.enableHelpHoverEffect,
   };
   return inputLabelProps;
 };
@@ -102,7 +102,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
   DisableClearable extends boolean | undefined = undefined, FreeSolo extends boolean | undefined = undefined>
   ({ ...props }: AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>) => {
   const {
-    helperText, helperIconTooltip, actionProps, focused, hiddenLabel, nonEdit, enableHoverEffect, renderNonEditInput, endAdornmentAction, ...rest // clean up rest of props for MuiAutocomplete tag
+    helperText, helperIconTooltip, actionProps, focused, hiddenLabel, nonEdit, enableHelpHoverEffect, renderNonEditInput, endAdornmentAction, ...rest // clean up rest of props for MuiAutocomplete tag
   } = props;
 
   // prevents DOM warning for error=boolean
@@ -159,7 +159,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
               renderNonEditInput,
               endAdornmentAction,
               value: props.value,
-              enableHoverEffect,
+              enableHelpHoverEffect,
             };
             const tooltipTitle = isValueOverFlowing ? textfieldRef.current?.value || '' : '';
             textFieldArgs.inputProps = {

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -102,7 +102,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
   DisableClearable extends boolean | undefined = undefined, FreeSolo extends boolean | undefined = undefined>
   ({ ...props }: AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>) => {
   const {
-    helperText, helperIconTooltip, actionProps, focused, hiddenLabel, nonEdit, renderNonEditInput, endAdornmentAction, ...rest // clean up rest of props for MuiAutocomplete tag
+    helperText, helperIconTooltip, actionProps, focused, hiddenLabel, nonEdit, enableHoverEffect, renderNonEditInput, endAdornmentAction, ...rest // clean up rest of props for MuiAutocomplete tag
   } = props;
 
   // prevents DOM warning for error=boolean
@@ -159,6 +159,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
               renderNonEditInput,
               endAdornmentAction,
               value: props.value,
+              enableHoverEffect,
             };
             const tooltipTitle = isValueOverFlowing ? textfieldRef.current?.value || '' : '';
             textFieldArgs.inputProps = {

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -38,6 +38,7 @@ export interface AutocompleteProps<T, Multiple, DisableClearable, FreeSolo> exte
   actionProps?: ActionProps[];
   nonEdit?: boolean;
   helperText?: string;
+  enableHoverEffect?: boolean;
   helperIconTooltip?: string;
   tooltipPlacement?: TooltipPlacement;
   label?: string;
@@ -50,7 +51,6 @@ export interface AutocompleteProps<T, Multiple, DisableClearable, FreeSolo> exte
   endAdornmentAction?: React.ReactNode;
   renderNonEditInput?: () => React.ReactNode;
   placeholder?: string;
-  enableHoverEffect?: boolean;
 }
 
 const getMuiFormControlProps = <T, Multiple extends boolean | undefined = undefined,

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -50,6 +50,7 @@ export interface AutocompleteProps<T, Multiple, DisableClearable, FreeSolo> exte
   endAdornmentAction?: React.ReactNode;
   renderNonEditInput?: () => React.ReactNode;
   placeholder?: string;
+  iconHoverEffect?: boolean;
 }
 
 const getMuiFormControlProps = <T, Multiple extends boolean | undefined = undefined,
@@ -92,6 +93,7 @@ DisableClearable extends boolean | undefined = undefined, FreeSolo extends boole
     hiddenLabel: props.hiddenLabel,
     isFocus,
     fullWidth: props.fullWidth,
+    iconHoverEffect: props.iconHoverEffect,
   };
   return inputLabelProps;
 };

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -50,7 +50,7 @@ export interface AutocompleteProps<T, Multiple, DisableClearable, FreeSolo> exte
   endAdornmentAction?: React.ReactNode;
   renderNonEditInput?: () => React.ReactNode;
   placeholder?: string;
-  iconHoverEffect?: boolean;
+  enableHoverEffect?: boolean;
 }
 
 const getMuiFormControlProps = <T, Multiple extends boolean | undefined = undefined,
@@ -93,7 +93,7 @@ DisableClearable extends boolean | undefined = undefined, FreeSolo extends boole
     hiddenLabel: props.hiddenLabel,
     isFocus,
     fullWidth: props.fullWidth,
-    iconHoverEffect: props.iconHoverEffect,
+    enableHoverEffect: props.enableHoverEffect,
   };
   return inputLabelProps;
 };

--- a/src/DatePicker/DatePicker.stories.tsx
+++ b/src/DatePicker/DatePicker.stories.tsx
@@ -65,10 +65,10 @@ export default {
         defaultValue: { summary: DatePicker.defaultProps.helperText },
       },
     },
-    enableHoverEffect: {
+    enableHelpHoverEffect: {
       control: 'boolean',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.enableHoverEffect },
+        defaultValue: { summary: DatePicker.defaultProps.enableHelpHoverEffect },
       },
       description: 'If true, the helper icon displays a gray background when hovered.',
     },

--- a/src/DatePicker/DatePicker.stories.tsx
+++ b/src/DatePicker/DatePicker.stories.tsx
@@ -1,5 +1,5 @@
 /* ======================================================================== *
- * Copyright 2024 HCL America Inc.                                          *
+ * Copyright 2024, 2025 HCL America Inc.                                    *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
  * You may obtain a copy of the License at                                  *
@@ -64,6 +64,13 @@ export default {
       table: {
         defaultValue: { summary: DatePicker.defaultProps.helperText },
       },
+    },
+    enableHoverEffect: {
+      control: 'boolean',
+      table: {
+        defaultValue: { summary: DatePicker.defaultProps.enableHoverEffect },
+      },
+      description: 'If true, the helper icon displays a gray background when hovered.',
     },
     helperIconTooltip: {
       description: 'Attribute to set t of the tooltip for the helper icon.',

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -1,5 +1,5 @@
 /* ======================================================================== *
- * Copyright 2024 HCL America Inc.                                          *
+ * Copyright 2024, 2025 HCL America Inc.                                    *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
  * You may obtain a copy of the License at                                  *
@@ -31,6 +31,7 @@ const DEFAULT_FORMAT: string = 'MM/DD/YYYY';
 export interface DatePickerProps<TInputDate, TDate> extends Omit<MuiDatePickerProps<TInputDate, TDate>, 'renderInput'> {
   label?: string;
   helperText?: string;
+  enableHoverEffect?: boolean,
   helperIconTooltip?: string;
   format?: string,
   margin?: 'none' | 'dense';
@@ -239,6 +240,7 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
       inputRef: muiTextFieldProps.inputRef,
       label: props.label,
       helperText: props.helperText,
+      enableHoverEffect: props.enableHoverEffect,
       helperIconTooltip: props.helperIconTooltip,
       required: props.required,
       disabled: props.disabled,
@@ -348,6 +350,7 @@ DatePicker.defaultProps = {
   size: 'medium',
   label: '',
   helperText: '',
+  enableHoverEffect: false,
   helperIconTooltip: '',
   format: DEFAULT_FORMAT,
   unitLabel: '',

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -31,7 +31,7 @@ const DEFAULT_FORMAT: string = 'MM/DD/YYYY';
 export interface DatePickerProps<TInputDate, TDate> extends Omit<MuiDatePickerProps<TInputDate, TDate>, 'renderInput'> {
   label?: string;
   helperText?: string;
-  enableHoverEffect?: boolean,
+  enableHelpHoverEffect?: boolean,
   helperIconTooltip?: string;
   format?: string,
   margin?: 'none' | 'dense';
@@ -240,7 +240,7 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
       inputRef: muiTextFieldProps.inputRef,
       label: props.label,
       helperText: props.helperText,
-      enableHoverEffect: props.enableHoverEffect,
+      enableHelpHoverEffect: props.enableHelpHoverEffect,
       helperIconTooltip: props.helperIconTooltip,
       required: props.required,
       disabled: props.disabled,
@@ -350,7 +350,7 @@ DatePicker.defaultProps = {
   size: 'medium',
   label: '',
   helperText: '',
-  enableHoverEffect: false,
+  enableHelpHoverEffect: false,
   helperIconTooltip: '',
   format: DEFAULT_FORMAT,
   unitLabel: '',

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -119,6 +119,7 @@ const getMuiSelectProps = (props: SelectProps): MuiSelectProps => {
   delete cleanedProps.helperIconTooltip;
   delete cleanedProps.helperText;
   delete cleanedProps.hiddenLabel;
+  delete cleanedProps.enableHoverEffect;
 
   const handleMouseDown = ((event: React.MouseEvent<HTMLElement>) => {
     if (props.disabled || props.readOnly) {

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -33,7 +33,7 @@ export interface SelectProps extends MuiSelectProps {
   nonEdit?: boolean;
   actionProps?: ActionProps[];
   helperText?: string;
-  enableHoverEffect?: boolean;
+  enableHelpHoverEffect?: boolean;
   helperIconTooltip?: string;
   margin?: 'none' | 'dense';
   color?: 'primary';
@@ -119,7 +119,7 @@ const getMuiSelectProps = (props: SelectProps): MuiSelectProps => {
   delete cleanedProps.helperIconTooltip;
   delete cleanedProps.helperText;
   delete cleanedProps.hiddenLabel;
-  delete cleanedProps.enableHoverEffect;
+  delete cleanedProps.enableHelpHoverEffect;
 
   const handleMouseDown = ((event: React.MouseEvent<HTMLElement>) => {
     if (props.disabled || props.readOnly) {
@@ -248,7 +248,7 @@ const getInputLabelAndActionProps = (props : SelectProps): InputLabelAndActionPr
     actionProps: props.actionProps,
     hiddenLabel: props.hiddenLabel,
     fullWidth: props.fullWidth,
-    enableHoverEffect: props.enableHoverEffect,
+    enableHelpHoverEffect: props.enableHelpHoverEffect,
   };
   return inputLabelProps;
 };
@@ -276,7 +276,7 @@ Select.defaultProps = {
   size: 'medium',
   label: '',
   helperText: '',
-  enableHoverEffect: false,
+  enableHelpHoverEffect: false,
   helperIconTooltip: '',
   placeholder: '',
   unitLabel: '',

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -1,5 +1,5 @@
 /* ======================================================================== *
- * Copyright 2024 HCL America Inc.                                          *
+ * Copyright 2024, 2025 HCL America Inc.                                    *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
  * You may obtain a copy of the License at                                  *
@@ -33,6 +33,7 @@ export interface SelectProps extends MuiSelectProps {
   nonEdit?: boolean;
   actionProps?: ActionProps[];
   helperText?: string;
+  enableHoverEffect?: boolean;
   helperIconTooltip?: string;
   margin?: 'none' | 'dense';
   color?: 'primary';
@@ -246,6 +247,7 @@ const getInputLabelAndActionProps = (props : SelectProps): InputLabelAndActionPr
     actionProps: props.actionProps,
     hiddenLabel: props.hiddenLabel,
     fullWidth: props.fullWidth,
+    enableHoverEffect: props.enableHoverEffect,
   };
   return inputLabelProps;
 };
@@ -273,6 +275,7 @@ Select.defaultProps = {
   size: 'medium',
   label: '',
   helperText: '',
+  enableHoverEffect: false,
   helperIconTooltip: '',
   placeholder: '',
   unitLabel: '',

--- a/src/Select/SelectMultiple.stories.tsx
+++ b/src/Select/SelectMultiple.stories.tsx
@@ -43,7 +43,7 @@ export default {
     helperText: {
       description: 'The label of the helpertext.',
     },
-    enableHoverEffect: {
+    enableHelpHoverEffect: {
       control: 'boolean',
       table: {
         defaultValue: { summary: false },

--- a/src/Select/SelectMultiple.stories.tsx
+++ b/src/Select/SelectMultiple.stories.tsx
@@ -1,5 +1,5 @@
 /* ======================================================================== *
- * Copyright 2024 HCL America Inc.                                          *
+ * Copyright 2024, 2025 HCL America Inc.                                    *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
  * You may obtain a copy of the License at                                  *
@@ -42,6 +42,13 @@ export default {
     },
     helperText: {
       description: 'The label of the helpertext.',
+    },
+    enableHoverEffect: {
+      control: 'boolean',
+      table: {
+        defaultValue: { summary: false },
+      },
+      description: 'If true, the helper icon displays a gray background when hovered.',
     },
     placeholder: {
       description: 'The short hint displayed in the input before the user enters a value.',

--- a/src/TextField/TextField.stories.tsx
+++ b/src/TextField/TextField.stories.tsx
@@ -1,5 +1,5 @@
 /* ======================================================================== *
- * Copyright 2024 HCL America Inc.                                          *
+ * Copyright 2024, 2025 HCL America Inc.                                    *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
  * You may obtain a copy of the License at                                  *
@@ -71,6 +71,13 @@ export default {
       table: {
         defaultValue: { summary: TextField.defaultProps?.helperText },
       },
+    },
+    enableHoverEffect: {
+      control: 'boolean',
+      table: {
+        defaultValue: { summary: false },
+      },
+      description: 'If true, the helper icon displays a gray background when hovered.',
     },
     helperIconTooltip: {
       description: 'Attribute to set t of the tooltip for the helper icon.',
@@ -174,6 +181,7 @@ export const ExampleTextField = {
     label: 'Label',
     id: 'input-id',
     helperText: 'Some important text',
+    enableHoverEffect: false,
     helperIconTooltip: 'Some information about that component.',
     placeholder: 'Placeholder',
     unitLabel: 'kg',

--- a/src/TextField/TextField.stories.tsx
+++ b/src/TextField/TextField.stories.tsx
@@ -72,7 +72,7 @@ export default {
         defaultValue: { summary: TextField.defaultProps?.helperText },
       },
     },
-    enableHoverEffect: {
+    enableHelpHoverEffect: {
       control: 'boolean',
       table: {
         defaultValue: { summary: false },
@@ -181,7 +181,7 @@ export const ExampleTextField = {
     label: 'Label',
     id: 'input-id',
     helperText: 'Some important text',
-    enableHoverEffect: false,
+    enableHelpHoverEffect: false,
     helperIconTooltip: 'Some information about that component.',
     placeholder: 'Placeholder',
     unitLabel: 'kg',

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -1,5 +1,5 @@
 /* ======================================================================== *
- * Copyright 2024 HCL America Inc.                                          *
+ * Copyright 2024, 2025 HCL America Inc.                                    *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
  * You may obtain a copy of the License at                                  *
@@ -42,6 +42,7 @@ export interface TextFieldProps extends Omit<OutlinedTextFieldProps, 'variant'> 
   nonEdit?: boolean;
   actionProps?: ActionProps[];
   helperText?: string;
+  enableHoverEffect?: boolean;
   helperIconTooltip?: string;
   margin?: 'none' | 'dense';
   color?: 'primary';
@@ -305,6 +306,7 @@ const getInputLabelAndActionProps = (props: TextFieldProps, isFocus: boolean): I
     hiddenLabel: props.hiddenLabel,
     fullWidth: props.fullWidth,
     isFocus,
+    enableHoverEffect: props.enableHoverEffect,
   };
   return inputLabelProps;
 };

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -42,7 +42,7 @@ export interface TextFieldProps extends Omit<OutlinedTextFieldProps, 'variant'> 
   nonEdit?: boolean;
   actionProps?: ActionProps[];
   helperText?: string;
-  enableHoverEffect?: boolean;
+  enableHelpHoverEffect?: boolean;
   helperIconTooltip?: string;
   margin?: 'none' | 'dense';
   color?: 'primary';
@@ -306,7 +306,7 @@ const getInputLabelAndActionProps = (props: TextFieldProps, isFocus: boolean): I
     hiddenLabel: props.hiddenLabel,
     fullWidth: props.fullWidth,
     isFocus,
-    enableHoverEffect: props.enableHoverEffect,
+    enableHelpHoverEffect: props.enableHelpHoverEffect,
   };
   return inputLabelProps;
 };
@@ -337,7 +337,7 @@ const getMuiTextFieldProps = (props: TextFieldProps): OutlinedTextFieldProps => 
   delete cleanedProps.helperIconTooltip;
   delete cleanedProps.renderNonEditInput;
   delete cleanedProps.endAdornmentAction;
-  delete cleanedProps.enableHoverEffect;
+  delete cleanedProps.enableHelpHoverEffect;
 
   const muiTextFieldProps: OutlinedTextFieldProps = {
     ...cleanedProps,

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -337,6 +337,8 @@ const getMuiTextFieldProps = (props: TextFieldProps): OutlinedTextFieldProps => 
   delete cleanedProps.helperIconTooltip;
   delete cleanedProps.renderNonEditInput;
   delete cleanedProps.endAdornmentAction;
+  delete cleanedProps.enableHoverEffect;
+
   const muiTextFieldProps: OutlinedTextFieldProps = {
     ...cleanedProps,
     variant: 'outlined',

--- a/src/composite_components/MultipleSelectChip/MultipleSelectChip.stories.tsx
+++ b/src/composite_components/MultipleSelectChip/MultipleSelectChip.stories.tsx
@@ -112,7 +112,7 @@ export default {
       description:
         'The system prop that allows defining system overrides as well as additional CSS styles.',
     },
-    enableHoverEffect: {
+    enableHelpHoverEffect: {
       control: 'boolean',
       table: {
         defaultValue: { summary: false },
@@ -309,7 +309,7 @@ export const ExampleMultipleSelectChip = {
     size: 'medium',
     label: 'Example label',
     helperText: 'Helper text',
-    enableHoverEffect: false,
+    enableHelpHoverEffect: false,
     helperIconTooltip: 'Some information about that component.',
     tooltipPlacement: TooltipPlacement.BOTTOM,
     placeholder: 'Placeholder',

--- a/src/composite_components/MultipleSelectChip/MultipleSelectChip.stories.tsx
+++ b/src/composite_components/MultipleSelectChip/MultipleSelectChip.stories.tsx
@@ -1,5 +1,5 @@
 /* ======================================================================== *
- * Copyright 2024 HCL America Inc.                                          *
+ * Copyright 2024, 2025 HCL America Inc.                                    *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
  * You may obtain a copy of the License at                                  *
@@ -111,6 +111,13 @@ export default {
     sx: {
       description:
         'The system prop that allows defining system overrides as well as additional CSS styles.',
+    },
+    enableHoverEffect: {
+      control: 'boolean',
+      table: {
+        defaultValue: { summary: false },
+      },
+      description: 'If true, the helper icon displays a gray background when hovered.',
     },
     placeholder: {
       description:
@@ -302,6 +309,7 @@ export const ExampleMultipleSelectChip = {
     size: 'medium',
     label: 'Example label',
     helperText: 'Helper text',
+    enableHoverEffect: false,
     helperIconTooltip: 'Some information about that component.',
     tooltipPlacement: TooltipPlacement.BOTTOM,
     placeholder: 'Placeholder',

--- a/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
+++ b/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
@@ -57,8 +57,8 @@ export const MuiInputHelpIcon = styled(HelpIcon)<{ enableHoverEffect?: boolean }
     fontSize: '16px',
     ...(enableHoverEffect && {
       ':hover': {
-        borderRadius: '4px',
-        backgroundColor: theme.palette.grey[100],
+        borderRadius: '10px',
+        backgroundColor: theme.palette.grey[200],
       },
     }),
   };

--- a/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
+++ b/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
@@ -1,5 +1,5 @@
 /* ======================================================================== *
- * Copyright 2024 HCL America Inc.                                          *
+ * Copyright 2024, 2025 HCL America Inc.                                    *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
  * You may obtain a copy of the License at                                  *
@@ -37,6 +37,7 @@ export interface InputLabelAndActionProps extends MuiInputLabelProps {
   label?: ReactNode | string;
   isFocus?: boolean;
   fullWidth?: boolean;
+  iconHoverEffect?: boolean;
 }
 
 export const labelFocus = styled('div')((theme) => {
@@ -48,12 +49,18 @@ export const labelFocus = styled('div')((theme) => {
   };
 });
 
-export const MuiInputHelpIcon = styled(HelpIcon)((theme) => {
+export const MuiInputHelpIcon = styled(HelpIcon)<{ iconHoverEffect?: boolean }>(({ theme, iconHoverEffect }) => {
   return {
-    ...theme.theme.typography.subtitle2,
+    ...theme.typography.subtitle2,
     marginLeft: '8px',
     marginBottom: '-4px',
     fontSize: '16px',
+    ...(iconHoverEffect && {
+      ':hover': {
+        borderRadius: '4px',
+        backgroundColor: theme.palette.grey[200],
+      },
+    }),
   };
 });
 
@@ -111,7 +118,7 @@ const renderInputLabel = (props: InputLabelAndActionProps) => {
           title={props.helperIconTooltip}
           placement={props.tooltipPlacement || TooltipPlacement.BOTTOM}
         >
-          <MuiInputHelpIcon color="action" fontSize="small" />
+          <MuiInputHelpIcon color="action" fontSize="small" tabIndex={0} iconHoverEffect={props.iconHoverEffect} />
         </Tooltip>
       ) : (
         ''

--- a/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
+++ b/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
@@ -37,7 +37,7 @@ export interface InputLabelAndActionProps extends MuiInputLabelProps {
   label?: ReactNode | string;
   isFocus?: boolean;
   fullWidth?: boolean;
-  iconHoverEffect?: boolean;
+  enableHoverEffect?: boolean;
 }
 
 export const labelFocus = styled('div')((theme) => {
@@ -49,16 +49,16 @@ export const labelFocus = styled('div')((theme) => {
   };
 });
 
-export const MuiInputHelpIcon = styled(HelpIcon)<{ iconHoverEffect?: boolean }>(({ theme, iconHoverEffect }) => {
+export const MuiInputHelpIcon = styled(HelpIcon)<{ enableHoverEffect?: boolean }>(({ theme, enableHoverEffect }) => {
   return {
     ...theme.typography.subtitle2,
     marginLeft: '8px',
     marginBottom: '-4px',
     fontSize: '16px',
-    ...(iconHoverEffect && {
+    ...(enableHoverEffect && {
       ':hover': {
         borderRadius: '4px',
-        backgroundColor: theme.palette.grey[200],
+        backgroundColor: theme.palette.grey[100],
       },
     }),
   };
@@ -118,7 +118,7 @@ const renderInputLabel = (props: InputLabelAndActionProps) => {
           title={props.helperIconTooltip}
           placement={props.tooltipPlacement || TooltipPlacement.BOTTOM}
         >
-          <MuiInputHelpIcon color="action" fontSize="small" tabIndex={0} iconHoverEffect={props.iconHoverEffect} />
+          <MuiInputHelpIcon color="action" fontSize="small" tabIndex={0} enableHoverEffect={props.enableHoverEffect} />
         </Tooltip>
       ) : (
         ''

--- a/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
+++ b/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
@@ -49,7 +49,10 @@ export const labelFocus = styled('div')((theme) => {
   };
 });
 
-export const MuiInputHelpIcon = styled(HelpIcon)<{ enableHoverEffect?: boolean }>(({ theme, enableHoverEffect }) => {
+export const MuiInputHelpIcon = styled(HelpIcon, {
+  // Prevent `enableHoverEffect` from being passed to the DOM
+  shouldForwardProp: (prop) => { return prop !== 'enableHoverEffect'; },
+})<{ enableHoverEffect?: boolean }>(({ theme, enableHoverEffect }) => {
   return {
     ...theme.typography.subtitle2,
     marginLeft: '8px',

--- a/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
+++ b/src/prerequisite_components/InputLabelAndAction/InputLabelAndAction.tsx
@@ -37,7 +37,7 @@ export interface InputLabelAndActionProps extends MuiInputLabelProps {
   label?: ReactNode | string;
   isFocus?: boolean;
   fullWidth?: boolean;
-  enableHoverEffect?: boolean;
+  enableHelpHoverEffect?: boolean;
 }
 
 export const labelFocus = styled('div')((theme) => {
@@ -50,15 +50,15 @@ export const labelFocus = styled('div')((theme) => {
 });
 
 export const MuiInputHelpIcon = styled(HelpIcon, {
-  // Prevent `enableHoverEffect` from being passed to the DOM
-  shouldForwardProp: (prop) => { return prop !== 'enableHoverEffect'; },
-})<{ enableHoverEffect?: boolean }>(({ theme, enableHoverEffect }) => {
+  // Prevent `enableHelpHoverEffect` from being passed to the DOM
+  shouldForwardProp: (prop) => { return prop !== 'enableHelpHoverEffect'; },
+})<{ enableHelpHoverEffect?: boolean }>(({ theme, enableHelpHoverEffect }) => {
   return {
     ...theme.typography.subtitle2,
     marginLeft: '8px',
     marginBottom: '-4px',
     fontSize: '16px',
-    ...(enableHoverEffect && {
+    ...(enableHelpHoverEffect && {
       ':hover': {
         borderRadius: '10px',
         backgroundColor: theme.palette.grey[200],
@@ -121,7 +121,7 @@ const renderInputLabel = (props: InputLabelAndActionProps) => {
           title={props.helperIconTooltip}
           placement={props.tooltipPlacement || TooltipPlacement.BOTTOM}
         >
-          <MuiInputHelpIcon color="action" fontSize="small" tabIndex={0} enableHoverEffect={props.enableHoverEffect} />
+          <MuiInputHelpIcon color="action" fontSize="small" tabIndex={0} enableHelpHoverEffect={props.enableHelpHoverEffect} />
         </Tooltip>
       ) : (
         ''


### PR DESCRIPTION
Jira ticket: https://hclsw-jirads.atlassian.net/browse/DXQ-41961

Changes
- Added a tabIndex to the MuiHelperIcon so it can be read by screen readers.
- Added an enableHoverEffect to provide a gray shade on the help icon when hovered.