### PR TITLE
DXQ-43848-Text-(Font)---Tooltip-and-ellipse-issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fixed the tooltip in Autocomplete and adjusted the marginRight (px) to prevent truncation in small width.
 
 ### Added
 
@@ -22,7 +23,6 @@
 - Fixed Progress Bar Storybook update
 - Fixed the CSS for ProgressBarHeader to ensure text displays in a single line.
 - Fixed click on Select down arrow to open menu (https://github.com/HCL-TECH-SOFTWARE/enchanted-react-components/issues/302)
-- Fixed the tooltip in Autocomplete and adjusted the marginRight (px) to prevent truncation in small width.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
 ## Unreleased
-- Fixed the tooltip in Autocomplete and adjusted the marginRight (px) to prevent truncation in small width.
 
 ### Added
 
 ### Fixed
 - Fixed ref forwarding support for the `ListItem` component, allowing access to the underlying DOM element.
+- Fixed the tooltip in Autocomplete and adjusted the marginRight (px) to prevent truncation in small width.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed Progress Bar Storybook update
 - Fixed the CSS for ProgressBarHeader to ensure text displays in a single line.
 - Fixed click on Select down arrow to open menu (https://github.com/HCL-TECH-SOFTWARE/enchanted-react-components/issues/302)
+- Fixed the tooltip in Autocomplete and adjusted the marginRight (px) to prevent truncation in small width.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 - Fixed ref forwarding support for the `ListItem` component, allowing access to the underlying DOM element.
-- Fixed the tooltip in Autocomplete and adjusted the marginRight (px) to prevent truncation in small width.
+- Fixed the tooltip in Autocomplete.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 - Fixed ref forwarding support for the `ListItem` component, allowing access to the underlying DOM element.
-- Fixed the tooltip in Autocomplete.
+- Fixed the issue where the Autocomplete tooltip was overwritten by transient input.
 
 ### Changed
 

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -224,6 +224,11 @@ const Template: StoryFn<typeof Autocomplete> = (args) => {
     <Autocomplete
       value={value}
       autoHighlight
+      onInput={(event) => {
+        if (args.freeSolo) {
+          setValue((event.target as HTMLInputElement).value);
+        }
+      }}
       onChange={(event, newValue) => {
         setValue(newValue as string);
       }}

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -148,10 +148,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
               error: Boolean(props.error),
               required: props.required,
               fullWidth: props.fullWidth,
-              sx: {
-                ...props.sx,
-                width: 220,
-              },
+              sx: props.sx,
               focused,
               hiddenLabel,
               helperIconTooltip,
@@ -173,7 +170,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
                 },
               );
 
-            const tooltipTitle = (isValueOverFlowing && isInputValueInOptions && textFieldArgs.value?.label) ? textFieldArgs.value.label : '';
+            const tooltipTitle = (isValueOverFlowing && (isInputValueInOptions || !isFocus) && textFieldArgs.value?.label) ? textFieldArgs.value.label : '';
 
             textFieldArgs.inputProps = {
               'aria-describedby': props.error ? undefined : helperTextId,

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -117,6 +117,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
   const inputLabelAndActionProps = getInputLabelAndActionProps(props, isFocus);
   const textfieldRef = React.useRef<HTMLInputElement>(null);
   const [isValueOverFlowing, setIsValueOverFlowing] = React.useState(false);
+  const [prevValue, setPrevValue] = React.useState('');
 
   React.useEffect(() => {
     const textFieldElement = textfieldRef.current;
@@ -138,6 +139,9 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
           }}
           onBlur={() => {
             setIsFocus(false);
+            if (textfieldRef.current) {
+              setPrevValue(textfieldRef.current.value);
+            }
           }}
           clearIcon={props.clearIcon ? props.clearIcon : <ClearIcon color="action" />}
           popupIcon={<CaretDownIcon color="action" />}
@@ -163,14 +167,17 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
             };
 
             const inputValue = textfieldRef.current?.value ?? '';
-            const isInputValueInOptions = Array.isArray(props.options)
-              && props.options.some(
-                (option) => {
-                  return option && typeof option === 'object' && 'label' in option && option.label === inputValue;
-                },
-              );
+            let tooltipTitle = '';
 
-            const tooltipTitle = (isValueOverFlowing && (isInputValueInOptions || !isFocus) && textFieldArgs.value?.label) ? textFieldArgs.value.label : '';
+            if (isValueOverFlowing) {
+              if (props.freeSolo) {
+                tooltipTitle = inputValue;
+              } else if (inputValue === prevValue) {
+                tooltipTitle = textFieldArgs.value?.label ?? '';
+              } else {
+                tooltipTitle = inputValue;
+              }
+            }
 
             textFieldArgs.inputProps = {
               'aria-describedby': props.error ? undefined : helperTextId,

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -118,6 +118,9 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
   const textfieldRef = React.useRef<HTMLInputElement>(null);
   const [isValueOverFlowing, setIsValueOverFlowing] = React.useState(false);
 
+  //
+  const [isInputInOptions, setIsInputInOptions] = React.useState(false);
+
   React.useEffect(() => {
     const textFieldElement = textfieldRef.current;
     if (textFieldElement && textFieldElement.scrollWidth > textFieldElement.clientWidth) {
@@ -141,6 +144,17 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
           }}
           clearIcon={props.clearIcon ? props.clearIcon : <ClearIcon color="action" />}
           popupIcon={<CaretDownIcon color="action" />}
+          // onInputChange={(_, value: string) => {
+          //   // setIsInputInOptions(isIncluded);
+          //   if (props && props.options) {
+          //     const isIncluded = props.options.some((option) => {
+          //       if (option && typeof option === 'object' && 'label' in option) return option.label === value;
+          //       return false;
+          //     });
+          //     console.log('isIncluded: ', isIncluded);
+          //     setIsInputInOptions(isIncluded);
+          //   }
+          // }}
           renderInput={(params) => {
             const textFieldArgs: TextFieldProps = {
               ...params,
@@ -161,13 +175,35 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
               value: props.value,
               enableHelpHoverEffect,
             };
-            const tooltipTitle = isValueOverFlowing ? textfieldRef.current?.value || '' : '';
+
+            // check if we can used the logic here
+            let isIncluded = false;
+            if (props && props.options) {
+              isIncluded = props.options.some((option) => {
+                if (option && typeof option === 'object' && 'label' in option) return option.label === textfieldRef.current?.value;
+                return false;
+              });
+              // setIsInputInOptions(isIncluded);
+            }
+
+            console.log('isIncluded: ', isIncluded);
+            console.log('type: ', textfieldRef.current?.value);
+
+            const tooltipTitle = (isValueOverFlowing && isIncluded) ? textFieldArgs.value.label || textfieldRef.current?.value : '';
+            // const tooltipTitle = (isValueOverFlowing && (textFieldArgs.value && textFieldArgs.value.label)) ? textFieldArgs.value.label || '' : '';
             textFieldArgs.inputProps = {
               'aria-describedby': props.error ? undefined : helperTextId,
               'aria-errormessage': props.error ? helperTextId : undefined,
               'aria-labelledby': props.id ? `${props.id}-label` : undefined,
               ...textFieldArgs.inputProps,
             };
+            // return (
+            //   isInputInOptions ? (
+            //     <Tooltip title={tooltipTitle} tooltipsize="small">
+            //       <TextField {...textFieldArgs} inputRef={textfieldRef} />
+            //     </Tooltip>
+            //   ) : <TextField {...textFieldArgs} inputRef={textfieldRef} />
+            // );
             return (
               <Tooltip title={tooltipTitle} tooltipsize="small">
                 <TextField {...textFieldArgs} inputRef={textfieldRef} />
@@ -233,7 +269,7 @@ export const getMuiAutocompleteThemeOverrides = (): Components<Omit<Theme, 'comp
                 '&.MuiOutlinedInput-root .MuiAutocomplete-input': { // for input truncation
                   ...TYPOGRAPHY.body2,
                   padding: '0px',
-                  marginRight: ownerState.error ? '58px' : '48px',
+                  marginRight: ownerState.error ? '58px' : '40px',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -244,7 +244,7 @@ export const getMuiAutocompleteThemeOverrides = (): Components<Omit<Theme, 'comp
                 '&.MuiOutlinedInput-root .MuiAutocomplete-input': { // for input truncation
                   ...TYPOGRAPHY.body2,
                   padding: '0px',
-                  marginRight: ownerState.error ? '66px' : '40px',
+                  marginRight: ownerState.error ? '64px' : '35px',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -117,7 +117,6 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
   const inputLabelAndActionProps = getInputLabelAndActionProps(props, isFocus);
   const textfieldRef = React.useRef<HTMLInputElement>(null);
   const [isValueOverFlowing, setIsValueOverFlowing] = React.useState(false);
-  const [inputWidth, setInputWidth] = React.useState<{parentWidth: number, currValue: string }>({ parentWidth: 0, currValue: '' });
 
   React.useEffect(() => {
     const textFieldElement = textfieldRef.current;
@@ -127,46 +126,6 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
       setIsValueOverFlowing(false);
     }
   }, [props.value]);
-
-  React.useEffect(() => {
-    if (textfieldRef.current) {
-      const parentWidth = textfieldRef.current.parentElement?.clientWidth || 0;
-      setInputWidth({
-        parentWidth,
-        currValue: textfieldRef.current.value,
-      });
-    }
-  }, [props.value, props.clearIcon, props.popupIcon, props.error, props.disabled, props.freeSolo]);
-
-  const getDynamicMarginRight = () : string => {
-    const { parentWidth, currValue } = inputWidth;
-    const {
-      disabled: isDisabled,
-      error: isError,
-      freeSolo: hasFreeSolo,
-    } = props;
-
-    // The value of 22px is based on the icon size
-    let value = 0;
-
-    // The two icon
-    if (!hasFreeSolo) {
-      if (isDisabled) {
-        value += (parentWidth <= 150 ? 0 : 22); // caret only
-      } else {
-        // eslint-why - using nested ternary to reduce unnecessary code blocks
-        // eslint-disable-next-line no-nested-ternary
-        value += currValue ? 44 : parentWidth > 150 ? 22 : 0; // both icons or caret only
-      }
-    }
-
-    // close icon
-    if (isError) {
-      value += 22;
-    }
-
-    return `${value}px`;
-  };
 
   return (
     <AutoCompleteContainer className="autocomplete-container">
@@ -201,12 +160,6 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
               endAdornmentAction,
               value: props.value,
               enableHelpHoverEffect,
-              inputProps: {
-                ...params.inputProps,
-                style: {
-                  marginRight: getDynamicMarginRight(),
-                },
-              },
             };
 
             const inputValue = textfieldRef.current?.value ?? '';
@@ -291,6 +244,7 @@ export const getMuiAutocompleteThemeOverrides = (): Components<Omit<Theme, 'comp
                 '&.MuiOutlinedInput-root .MuiAutocomplete-input': { // for input truncation
                   ...TYPOGRAPHY.body2,
                   padding: '0px',
+                  marginRight: ownerState.error ? '58px' : '48px',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -147,21 +147,25 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
     } = props;
 
     // The value of 22px is based on the icon size
-    if (parentWidth <= 150) {
-      let value = 0;
+    let value = 0;
 
-      if (isError) {
-        value += 22;
+    // The two icon
+    if (!hasFreeSolo) {
+      if (isDisabled) {
+        value += (parentWidth <= 150 ? 0 : 22); // caret only
+      } else {
+        // eslint-why - using nested ternary to reduce unnecessary code blocks
+        // eslint-disable-next-line no-nested-ternary
+        value += currValue ? 44 : parentWidth > 150 ? 22 : 0; // both icons or caret only
       }
-
-      if (!hasFreeSolo) {
-        value += currValue && !isDisabled ? 44 : 22;
-      }
-
-      return `${value}px`;
     }
 
-    return isError ? '68px' : '48px';
+    // close icon
+    if (isError) {
+      value += 22;
+    }
+
+    return `${value}px`;
   };
 
   return (

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -25,7 +25,6 @@ import { TYPOGRAPHY } from '../theme';
 import InputLabelAndAction, { InputLabelAndActionProps, ActionProps } from '../prerequisite_components/InputLabelAndAction/InputLabelAndAction';
 import TextField, { TextFieldProps } from '../TextField/TextField';
 import Tooltip, { TooltipPlacement } from '../Tooltip';
-import { width } from '@mui/system';
 
 /**
  * @typedef AutocompleteProps

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -151,10 +151,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
       if (!currValue) return isError ? '22px' : '0px';
 
       if (isDisabled) {
-        if (isError && !hasFreeSolo) return '44px';
-        if (isError || !hasFreeSolo) return '22px';
-        if (hasFreeSolo) return '22px';
-        return '0px';
+        return isError ? '22px' : '0px';
       }
 
       if (hasFreeSolo) return isError ? '22px' : '0px';
@@ -284,6 +281,7 @@ export const getMuiAutocompleteThemeOverrides = (): Components<Omit<Theme, 'comp
                 paddingBottom: '5px',
                 paddingLeft: '8px',
                 height: '28px',
+                width: '140px',
                 '&.MuiOutlinedInput-root .MuiAutocomplete-input': { // for input truncation
                   ...TYPOGRAPHY.body2,
                   padding: '0px',

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -25,6 +25,7 @@ import { TYPOGRAPHY } from '../theme';
 import InputLabelAndAction, { InputLabelAndActionProps, ActionProps } from '../prerequisite_components/InputLabelAndAction/InputLabelAndAction';
 import TextField, { TextFieldProps } from '../TextField/TextField';
 import Tooltip, { TooltipPlacement } from '../Tooltip';
+import { width } from '@mui/system';
 
 /**
  * @typedef AutocompleteProps
@@ -138,7 +139,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
     }
   }, [props.value, props.clearIcon, props.popupIcon, props.error, props.disabled, props.freeSolo]);
 
-  const getDynamicMarginRight = () => {
+  const getDynamicMarginRight = () : string => {
     const { parentWidth, currValue } = inputWidth;
     const {
       disabled: isDisabled,
@@ -146,16 +147,19 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
       freeSolo: hasFreeSolo,
     } = props;
 
-    // the value of 22px is based on the icon size 16px
+    // The value of 22px is based on the icon size
     if (parentWidth <= 150) {
-      if (!currValue) return isError ? '22px' : '0px';
+      let value = 0;
 
-      if (isDisabled) {
-        return isError ? '22px' : '0px';
+      if (isError) {
+        value += 22;
       }
 
-      if (hasFreeSolo) return isError ? '22px' : '0px';
-      return isError ? '66px' : '44px';
+      if (!hasFreeSolo) {
+        value += currValue && !isDisabled ? 44 : 22;
+      }
+
+      return `${value}px`;
     }
 
     return isError ? '68px' : '48px';
@@ -281,7 +285,6 @@ export const getMuiAutocompleteThemeOverrides = (): Components<Omit<Theme, 'comp
                 paddingBottom: '5px',
                 paddingLeft: '8px',
                 height: '28px',
-                width: '140px',
                 '&.MuiOutlinedInput-root .MuiAutocomplete-input': { // for input truncation
                   ...TYPOGRAPHY.body2,
                   padding: '0px',

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -118,9 +118,6 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
   const textfieldRef = React.useRef<HTMLInputElement>(null);
   const [isValueOverFlowing, setIsValueOverFlowing] = React.useState(false);
 
-  //
-  const [isInputInOptions, setIsInputInOptions] = React.useState(false);
-
   React.useEffect(() => {
     const textFieldElement = textfieldRef.current;
     if (textFieldElement && textFieldElement.scrollWidth > textFieldElement.clientWidth) {
@@ -144,17 +141,6 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
           }}
           clearIcon={props.clearIcon ? props.clearIcon : <ClearIcon color="action" />}
           popupIcon={<CaretDownIcon color="action" />}
-          // onInputChange={(_, value: string) => {
-          //   // setIsInputInOptions(isIncluded);
-          //   if (props && props.options) {
-          //     const isIncluded = props.options.some((option) => {
-          //       if (option && typeof option === 'object' && 'label' in option) return option.label === value;
-          //       return false;
-          //     });
-          //     console.log('isIncluded: ', isIncluded);
-          //     setIsInputInOptions(isIncluded);
-          //   }
-          // }}
           renderInput={(params) => {
             const textFieldArgs: TextFieldProps = {
               ...params,
@@ -162,7 +148,10 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
               error: Boolean(props.error),
               required: props.required,
               fullWidth: props.fullWidth,
-              sx: props.sx,
+              sx: {
+                ...props.sx,
+                width: 220,
+              },
               focused,
               hiddenLabel,
               helperIconTooltip,
@@ -176,34 +165,23 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
               enableHelpHoverEffect,
             };
 
-            // check if we can used the logic here
-            let isIncluded = false;
-            if (props && props.options) {
-              isIncluded = props.options.some((option) => {
-                if (option && typeof option === 'object' && 'label' in option) return option.label === textfieldRef.current?.value;
-                return false;
-              });
-              // setIsInputInOptions(isIncluded);
-            }
+            const inputValue = textfieldRef.current?.value ?? '';
+            const isInputValueInOptions = Array.isArray(props.options)
+              && props.options.some(
+                (option) => {
+                  return option && typeof option === 'object' && 'label' in option && option.label === inputValue;
+                },
+              );
 
-            console.log('isIncluded: ', isIncluded);
-            console.log('type: ', textfieldRef.current?.value);
+            const tooltipTitle = (isValueOverFlowing && isInputValueInOptions && textFieldArgs.value?.label) ? textFieldArgs.value.label : '';
 
-            const tooltipTitle = (isValueOverFlowing && isIncluded) ? textFieldArgs.value.label || textfieldRef.current?.value : '';
-            // const tooltipTitle = (isValueOverFlowing && (textFieldArgs.value && textFieldArgs.value.label)) ? textFieldArgs.value.label || '' : '';
             textFieldArgs.inputProps = {
               'aria-describedby': props.error ? undefined : helperTextId,
               'aria-errormessage': props.error ? helperTextId : undefined,
               'aria-labelledby': props.id ? `${props.id}-label` : undefined,
               ...textFieldArgs.inputProps,
             };
-            // return (
-            //   isInputInOptions ? (
-            //     <Tooltip title={tooltipTitle} tooltipsize="small">
-            //       <TextField {...textFieldArgs} inputRef={textfieldRef} />
-            //     </Tooltip>
-            //   ) : <TextField {...textFieldArgs} inputRef={textfieldRef} />
-            // );
+
             return (
               <Tooltip title={tooltipTitle} tooltipsize="small">
                 <TextField {...textFieldArgs} inputRef={textfieldRef} />
@@ -269,7 +247,7 @@ export const getMuiAutocompleteThemeOverrides = (): Components<Omit<Theme, 'comp
                 '&.MuiOutlinedInput-root .MuiAutocomplete-input': { // for input truncation
                   ...TYPOGRAPHY.body2,
                   padding: '0px',
-                  marginRight: ownerState.error ? '58px' : '40px',
+                  marginRight: ownerState.error ? '66px' : '40px',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',


### PR DESCRIPTION
Jira Ticket: https://hclsw-jirads.atlassian.net/browse/DXQ-43848
Tooltip
1. Look for long words Ex. The Lord of the Rings: The Return of the King
2. Then Select that word
3.  Ctrl + A, Then type Sha
4. Then Click tab

<img width="400" height="297" alt="Autocomplete" src="https://github.com/user-attachments/assets/1429970a-2894-421e-8c2c-a283d6351119" />

1. Look for long words Ex. The Lord of the Rings: The Return of the King
2. Ctrl + A, then type any word
3. Then click tab

<img width="352" height="286" alt="Autocomplete" src="https://github.com/user-attachments/assets/f975b52e-2628-47b1-a57b-cb53947a3ab9" />


Expected: The last type that we did is now a tooltip
Actual: it should be the one that is set on the field


Jira Ticket: https://hclsw-jirads.atlassian.net/browse/DXQ-45590
Truncate
