### PR TITLE
Static date picker added

### DIFF
--- a/.jest-reporter-log-validator-config.json
+++ b/.jest-reporter-log-validator-config.json
@@ -2,7 +2,7 @@
   "logValidations": [
     {
       "patterns": [""],
-      "max": 447
+      "max": 448
     }
   ],
   "exemptLogs": [],

--- a/.jest-reporter-log-validator-config.json
+++ b/.jest-reporter-log-validator-config.json
@@ -2,7 +2,7 @@
   "logValidations": [
     {
       "patterns": [""],
-      "max": 448
+      "max": 447
     }
   ],
   "exemptLogs": [],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- Add `staticMode` prop to DatePicker for rendering inline calendar via StaticDatePicker.
 
 ### Fixed
 

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -16,17 +16,11 @@
 import React from 'react';
 import MuiBadge, { BadgeProps } from '@mui/material/Badge';
 
-const Badge = ({ ...props }: BadgeProps) => {
-  return <MuiBadge {...props} />;
+const Badge = ({
+  color = 'primary', overlap = 'rectangular', variant = 'standard', ...props
+}: BadgeProps) => {
+  return <MuiBadge color={color} overlap={overlap} variant={variant} {...props} />;
 };
-
-const defaultProps: BadgeProps = {
-  color: 'primary',
-  overlap: 'rectangular',
-  variant: 'standard',
-};
-
-Badge.defaultProps = defaultProps;
 
 export * from '@mui/material/Badge';
 export default Badge;

--- a/src/DatePicker/DatePicker.stories.tsx
+++ b/src/DatePicker/DatePicker.stories.tsx
@@ -165,6 +165,15 @@ export default {
         },
       },
     },
+    staticMode: {
+      description: 'If true, renders a static date picker without input field. Useful for embedded calendar views.',
+      control: 'boolean',
+      table: {
+        defaultValue: {
+          summary: DatePicker.defaultProps.staticMode,
+        },
+      },
+    },
   },
 } as Meta<typeof DatePicker>;
 
@@ -265,5 +274,19 @@ export const ExampleDatePickerFullWidth = {
   args: {
     ...ExampleDatePicker.args,
     fullWidth: true,
+  },
+};
+
+export const ExampleStaticDatePicker = {
+  render: Template,
+  args: {
+    ...DatePicker.defaultProps,
+    staticMode: true,
+  },
+  parameters: {
+    controls: {
+      // Only show controls relevant to the static calendar — input-field-specific controls are not applicable
+      include: ['staticMode', 'disabled', 'showDaysOutsideCurrentMonth', 'adapterLocale'],
+    },
   },
 };

--- a/src/DatePicker/DatePicker.stories.tsx
+++ b/src/DatePicker/DatePicker.stories.tsx
@@ -20,7 +20,7 @@ import InformationIcon from '@hcl-software/enchanted-icons/dist/carbon/es/inform
 
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs, { Dayjs } from 'dayjs';
-import DatePicker from './DatePicker';
+import DatePicker, { DatePickerDefaults } from './DatePicker';
 import PickersLocalizationProvider, {
   SUPPORTED_LOCALE,
 } from '../PickersLocalizationProvider/PickersLocalizationProvider';
@@ -35,7 +35,7 @@ export default {
       options: ['dense', 'none'],
       control: { type: 'radio' },
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.margin },
+        defaultValue: { summary: DatePickerDefaults.margin },
       },
     },
     color: {
@@ -44,7 +44,7 @@ export default {
       options: ['primary'],
       control: { type: 'radio' },
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.color },
+        defaultValue: { summary: DatePickerDefaults.color },
       },
     },
     size: {
@@ -52,50 +52,50 @@ export default {
       options: ['medium'],
       control: { type: 'radio' },
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.size },
+        defaultValue: { summary: DatePickerDefaults.size },
       },
     },
     label: {
       description: 'Attribute to set the label.',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.label },
+        defaultValue: { summary: DatePickerDefaults.label },
       },
     },
     helperText: {
       description: 'Attribute to set the helper text.',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.helperText },
+        defaultValue: { summary: DatePickerDefaults.helperText },
       },
     },
     enableHelpHoverEffect: {
       control: 'boolean',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.enableHelpHoverEffect },
+        defaultValue: { summary: DatePickerDefaults.enableHelpHoverEffect },
       },
       description: 'If true, the helper icon displays a gray background when hovered.',
     },
     helperIconTooltip: {
       description: 'Attribute to set t of the tooltip for the helper icon.',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.helperIconTooltip },
+        defaultValue: { summary: DatePickerDefaults.helperIconTooltip },
       },
     },
     hiddenLabel: {
       description: 'If `true`, the label will hide.',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.hiddenLabel },
+        defaultValue: { summary: DatePickerDefaults.hiddenLabel },
       },
     },
     nonEdit: {
       description: 'If `true`, the component is only ready. No interactions are possible..',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.nonEdit },
+        defaultValue: { summary: DatePickerDefaults.nonEdit },
       },
     },
     disabled: {
       description: 'If `true`, the component is disabled.',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.disabled },
+        defaultValue: { summary: DatePickerDefaults.disabled },
       },
     },
     fullWidth: {
@@ -107,13 +107,13 @@ export default {
     required: {
       description: 'If `true`, the `input` element is required.',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.required },
+        defaultValue: { summary: DatePickerDefaults.required },
       },
     },
     showDaysOutsideCurrentMonth: {
       description: 'If true, days outside the current month are rendered',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.required },
+        defaultValue: { summary: DatePickerDefaults.showDaysOutsideCurrentMonth },
       },
     },
     actionProps: {
@@ -143,7 +143,7 @@ export default {
     format: {
       description: 'Attribute which is used to verified the date.',
       table: {
-        defaultValue: { summary: DatePicker.defaultProps.format },
+        defaultValue: { summary: DatePickerDefaults.format },
       },
       control: false,
     },
@@ -170,7 +170,7 @@ export default {
       control: 'boolean',
       table: {
         defaultValue: {
-          summary: DatePicker.defaultProps.staticMode,
+          summary: DatePickerDefaults.staticMode,
         },
       },
     },
@@ -178,7 +178,7 @@ export default {
 } as Meta<typeof DatePicker>;
 
 const Template: StoryFn<typeof DatePicker> = (args) => {
-  const [value, setValue] = React.useState<Dayjs | null>(args.value ? dayjs(args.value as string, DatePicker.defaultProps.format) : null);
+  const [value, setValue] = React.useState<Dayjs | null>(args.value ? dayjs(args.value as string, DatePickerDefaults.format) : null);
   // @ts-ignore - The adapterLocale control it's not a property of the DatePicker but it is need for PickersLocalizationProvider.
   const { adapterLocale } = args;
 
@@ -211,7 +211,7 @@ const Template: StoryFn<typeof DatePicker> = (args) => {
 export const ExampleDatePicker = {
   render: Template,
   args: {
-    ...DatePicker.defaultProps,
+    ...DatePickerDefaults,
     label: 'Label',
     helperText: 'Some important text',
     helperIconTooltip: 'Some information about that component.',
@@ -280,7 +280,7 @@ export const ExampleDatePickerFullWidth = {
 export const ExampleStaticDatePicker = {
   render: Template,
   args: {
-    ...DatePicker.defaultProps,
+    ...DatePickerDefaults,
     staticMode: true,
   },
   parameters: {

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -36,9 +36,6 @@ const dayOfWeekFormatter = (day: string) => { return day; };
 // Display mode for the static date picker
 const staticWrapperAs = 'desktop' as const;
 
-// Reduce animations for both static and regular date picker variants
-const shouldReduceAnimations = true;
-
 export interface DatePickerProps<TInputDate, TDate> extends Omit<MuiDatePickerProps<TInputDate, TDate>, 'renderInput'> {
   label?: string;
   helperText?: string;
@@ -236,49 +233,30 @@ export const DatePickerDefaults = {
   staticMode: false,
 };
 
-const DatePicker = <TInputDate, TDate>({
-  customStyles = {},
-  staticMode = false,
-  margin = 'none',
-  color = 'primary',
-  size = 'medium',
-  label = '',
-  helperText = '',
-  enableHelpHoverEffect = false,
-  helperIconTooltip = '',
-  format = DEFAULT_FORMAT,
-  unitLabel = '',
-  required = false,
-  disabled = false,
-  fullWidth = false,
-  hiddenLabel = false,
-  nonEdit = false,
-  showDaysOutsideCurrentMonth = true,
-  error = false,
-  ...rest
-}: DatePickerProps<TInputDate, TDate>) => {
-  // Reconstruct full props for spreading to MUI components and internal access
-  const props: DatePickerProps<TInputDate, TDate> = {
-    customStyles,
-    staticMode,
-    margin,
-    color,
-    size,
-    label,
-    helperText,
-    enableHelpHoverEffect,
-    helperIconTooltip,
-    format,
-    unitLabel,
-    required,
-    disabled,
-    fullWidth,
-    hiddenLabel,
-    nonEdit,
-    showDaysOutsideCurrentMonth,
-    error,
-    ...rest,
-  };
+const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate, TDate>) => {
+  const {
+    customStyles = {},
+    staticMode = false,
+    margin = 'none',
+    color = 'primary',
+    size = 'medium',
+    label = '',
+    helperText = '',
+    enableHelpHoverEffect = false,
+    helperIconTooltip = '',
+    format = DEFAULT_FORMAT,
+    unitLabel = '',
+    required = false,
+    disabled = false,
+    fullWidth = false,
+    hiddenLabel = false,
+    nonEdit = false,
+    error = false,
+    actionProps,
+    customIcon,
+    value,
+    ...muiProps
+  } = props;
   const popperId = uuid();
 
   const handleOnKeyDownLeft = (event: KeyboardEvent) => {
@@ -299,8 +277,8 @@ const DatePicker = <TInputDate, TDate>({
     }
   };
 
-  const formatValue = (value: Dayjs, dateFormat: string): string => {
-    return value.format(dateFormat);
+  const formatValue = (dateValue: Dayjs, dateFormat: string): string => {
+    return dateValue.format(dateFormat);
   };
   const focusDialog = () => {
     window.requestAnimationFrame(() => {
@@ -328,31 +306,31 @@ const DatePicker = <TInputDate, TDate>({
     const textFieldProps: TextFieldProps = {
       ...muiTextFieldProps as TextFieldProps,
       inputRef: muiTextFieldProps.inputRef,
-      label: props.label,
-      helperText: props.helperText,
-      enableHelpHoverEffect: props.enableHelpHoverEffect,
-      helperIconTooltip: props.helperIconTooltip,
-      required: props.required,
-      disabled: props.disabled,
-      margin: props.margin,
-      color: props.color,
-      size: props.size,
+      label,
+      helperText,
+      enableHelpHoverEffect,
+      helperIconTooltip,
+      required,
+      disabled,
+      margin,
+      color,
+      size,
       autoComplete: 'off',
-      error: props.error || hasError,
-      fullWidth: props.fullWidth,
-      unitLabel: props.unitLabel,
-      hiddenLabel: props.hiddenLabel,
-      nonEdit: props.nonEdit,
-      value: props.value !== null ? `${formatValue(props.value as unknown as Dayjs, props.format || DEFAULT_FORMAT)}` : '',
-      actionProps: props.actionProps,
+      error: error || hasError,
+      fullWidth,
+      unitLabel,
+      hiddenLabel,
+      nonEdit,
+      value: value !== null ? `${formatValue(value as unknown as Dayjs, format || DEFAULT_FORMAT)}` : '',
+      actionProps,
       InputProps: {
         ...muiTextFieldProps.InputProps,
       },
       inputProps: {
         ...muiTextFieldProps.inputProps,
-        placeholder: props.format,
+        placeholder: format,
       },
-      customIcon: props.customIcon,
+      customIcon,
     };
     return textFieldProps;
   };
@@ -410,9 +388,11 @@ const DatePicker = <TInputDate, TDate>({
         sx={(theme) => { return getDatePickerStyle(theme, customStyles, true); }}
       >
         <MuiStaticDatePicker
-          {...props as unknown as MuiStaticDatePickerProps<TInputDate, TDate>}
+          {...muiProps as unknown as MuiStaticDatePickerProps<TInputDate, TDate>}
+          disabled={disabled}
+          value={value}
           displayStaticWrapperAs={staticWrapperAs}
-          reduceAnimations={shouldReduceAnimations}
+          reduceAnimations
           dayOfWeekFormatter={dayOfWeekFormatter}
           componentsProps={{
             actionBar: { actions: ['today'] },
@@ -432,8 +412,10 @@ const DatePicker = <TInputDate, TDate>({
   // Render regular DatePicker with input field
   return (
     <MuiDatePicker
-      {...props}
-      reduceAnimations={shouldReduceAnimations}
+      {...muiProps}
+      disabled={disabled}
+      value={value}
+      reduceAnimations
       autoFocus={false}
       onOpen={focusDialog}
       dayOfWeekFormatter={dayOfWeekFormatter}

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -112,7 +112,7 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
     },
     '& .MuiDayPicker-weekDayLabel': {
       ...theme.typography.body2,
-      color: 'text.secondary',
+      color: theme.palette.text.secondary,
       margin: '4px 2px',
       width: '24px',
       padding: '0px',
@@ -156,10 +156,10 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
         position: 'relative',
       },
       '&.MuiPickersDay-dayOutsideMonth': {
-        color: 'text.disabled',
+        color: theme.palette.text.disabled,
       },
       '&:hover': {
-        backgroundColor: 'action.hover',
+        backgroundColor: theme.palette.action.hover,
       },
       '&:focus-visible': {
         backgroundColor: 'transparent',
@@ -167,25 +167,25 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
         outline: `1px solid ${theme.palette.action.focus}`,
         outlineOffset: '3px',
         '&:hover': {
-          backgroundColor: 'action.hover',
+          backgroundColor: theme.palette.action.hover,
           border: 'none',
           outline: `1px solid ${theme.palette.action.focus}`,
           outlineOffset: '3px',
         },
       },
       '&.Mui-selected': {
-        backgroundColor: 'primary.main',
-        color: 'text.tertiary1',
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.text.tertiary1,
         '&:hover': {
-          backgroundColor: 'primary.dark',
+          backgroundColor: theme.palette.primary.dark,
         },
         '&:focus-visible': {
-          backgroundColor: 'primary.main',
+          backgroundColor: theme.palette.primary.main,
           border: 'none',
           outline: `1px solid ${theme.palette.action.focus}`,
           outlineOffset: '3px',
           '&:hover': {
-            backgroundColor: 'primary.dark',
+            backgroundColor: theme.palette.primary.dark,
           },
         },
       },
@@ -203,7 +203,7 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
     },
     '& .MuiPickersArrowSwitcher-button': {
       '&:hover': {
-        backgroundColor: 'action.hover',
+        backgroundColor: theme.palette.action.hover,
       },
     },
     ...customStyles,

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -80,7 +80,12 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
       width: '228px',
       margin: '0px',
       height: 'auto',
+      overflowY: 'hidden',
       flexGrow: 1,
+    },
+    '& .MuiYearPicker-root': {
+      maxHeight: '168px',
+      overflowY: 'auto',
     },
     '& .MuiTouchRipple-root': {
       color: 'transparent',
@@ -196,6 +201,7 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
       display: '-webkit-box',
       padding: '12px 0px',
       justifyContent: 'center',
+      borderTop: 'none',
     },
     '& .MuiPickersArrowSwitcher-button': {
       '&:hover': {
@@ -206,8 +212,73 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
   };
 };
 
-const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate, TDate>) => {
-  const { customStyles = {}, staticMode = false } = props;
+/**
+ * Default prop values for DatePicker.
+ * Exported for use in Storybook argTypes and story args.
+ */
+export const DatePickerDefaults = {
+  margin: 'none' as const,
+  color: 'primary' as const,
+  size: 'medium' as const,
+  label: '',
+  helperText: '',
+  enableHelpHoverEffect: false,
+  helperIconTooltip: '',
+  format: DEFAULT_FORMAT,
+  unitLabel: '',
+  required: false,
+  disabled: false,
+  fullWidth: false,
+  hiddenLabel: false,
+  nonEdit: false,
+  showDaysOutsideCurrentMonth: true,
+  error: false,
+  staticMode: false,
+};
+
+const DatePicker = <TInputDate, TDate>({
+  customStyles = {},
+  staticMode = false,
+  margin = 'none',
+  color = 'primary',
+  size = 'medium',
+  label = '',
+  helperText = '',
+  enableHelpHoverEffect = false,
+  helperIconTooltip = '',
+  format = DEFAULT_FORMAT,
+  unitLabel = '',
+  required = false,
+  disabled = false,
+  fullWidth = false,
+  hiddenLabel = false,
+  nonEdit = false,
+  showDaysOutsideCurrentMonth = true,
+  error = false,
+  ...rest
+}: DatePickerProps<TInputDate, TDate>) => {
+  // Reconstruct full props for spreading to MUI components and internal access
+  const props: DatePickerProps<TInputDate, TDate> = {
+    customStyles,
+    staticMode,
+    margin,
+    color,
+    size,
+    label,
+    helperText,
+    enableHelpHoverEffect,
+    helperIconTooltip,
+    format,
+    unitLabel,
+    required,
+    disabled,
+    fullWidth,
+    hiddenLabel,
+    nonEdit,
+    showDaysOutsideCurrentMonth,
+    error,
+    ...rest,
+  };
   const popperId = uuid();
 
   const handleOnKeyDownLeft = (event: KeyboardEvent) => {
@@ -228,8 +299,8 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
     }
   };
 
-  const formatValue = (value: Dayjs, format: string): string => {
-    return value.format(format);
+  const formatValue = (value: Dayjs, dateFormat: string): string => {
+    return value.format(dateFormat);
   };
   const focusDialog = () => {
     window.requestAnimationFrame(() => {
@@ -246,12 +317,12 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
   };
 
   const getTextFieldProps = (muiTextFieldProps: MuiTextFieldProps) => {
-    let error = false;
+    let hasError = false;
     if (props.value !== null) {
       const day = props.value as unknown as Dayjs;
       if (!Number.isNaN(day.day()) && !Number.isNaN(day.month()) && !Number.isNaN(day.year())) {
         const valid = dayjs(day, props.format, true).isValid();
-        error = !valid;
+        hasError = !valid;
       }
     }
     const textFieldProps: TextFieldProps = {
@@ -267,7 +338,7 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
       color: props.color,
       size: props.size,
       autoComplete: 'off',
-      error: props.error || error,
+      error: props.error || hasError,
       fullWidth: props.fullWidth,
       unitLabel: props.unitLabel,
       hiddenLabel: props.hiddenLabel,
@@ -391,26 +462,6 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
       renderDay={renderDay}
     />
   );
-};
-
-DatePicker.defaultProps = {
-  margin: 'none',
-  color: 'primary',
-  size: 'medium',
-  label: '',
-  helperText: '',
-  enableHelpHoverEffect: false,
-  helperIconTooltip: '',
-  format: DEFAULT_FORMAT,
-  unitLabel: '',
-  required: false,
-  disabled: false,
-  fullWidth: false,
-  hiddenLabel: false,
-  nonEdit: false,
-  showDaysOutsideCurrentMonth: true,
-  error: false,
-  staticMode: false,
 };
 
 export * from '@mui/x-date-pickers/DatePicker';

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -14,11 +14,12 @@
  * ======================================================================== */
 import React, { KeyboardEvent } from 'react';
 import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatePickerProps } from '@mui/x-date-pickers/DatePicker';
-import { SvgIconProps, Theme } from '@mui/material';
+import { StaticDatePicker as MuiStaticDatePicker, StaticDatePickerProps as MuiStaticDatePickerProps } from '@mui/x-date-pickers/StaticDatePicker';
+import { Paper, SvgIconProps, Theme } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
 import { v4 as uuid } from 'uuid';
 import { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextField';
-import { PickersDay } from '@mui/x-date-pickers/PickersDay';
+import { PickersDay, PickersDayProps } from '@mui/x-date-pickers/PickersDay';
 import DotMark from '@hcl-software/enchanted-icons/dist/carbon/es/dot-mark';
 import IconCalendar from '@hcl-software/enchanted-icons/dist/carbon/es/calendar';
 import CaretDownIcon from '@hcl-software/enchanted-icons/dist/carbon/es/caret--down';
@@ -47,17 +48,24 @@ export interface DatePickerProps<TInputDate, TDate> extends Omit<MuiDatePickerPr
   actionProps?: ActionProps[];
   customStyles?: React.CSSProperties | {[key:string] : React.CSSProperties };
   customIcon?: React.ComponentType<SvgIconProps> | undefined;
+  /**
+   * If true, renders a static date picker without input field. Useful for embedded calendar views
+   */
+  staticMode?: boolean;
 }
 
-const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | {[key:string] : React.CSSProperties }) => {
+const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { [key: string]: React.CSSProperties }, staticMode?: boolean) => {
   return {
     ...theme.typography.body2,
-    margin: '6px 0px 0px -8px',
+    margin: staticMode ? '0px' : '6px 0px 0px -8px',
     padding: '0px',
     height: 'auto',
     width: '228px',
     color: `1px solid ${theme.palette.background.paper}`,
     boxShadow: theme.shadows[1],
+    '& .MuiPickerStaticWrapper-content': {
+      minWidth: 'unset',
+    },
     '& .MuiCalendarPicker-root': {
       width: '228px',
       margin: '0px',
@@ -178,6 +186,7 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | {[
       display: '-webkit-box',
       padding: '12px 0px',
       justifyContent: 'center',
+      borderTop: 'none',
     },
     '& .MuiPickersArrowSwitcher-button': {
       '&:hover': {
@@ -189,7 +198,7 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | {[
 };
 
 const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate, TDate>) => {
-  const { customStyles = {} } = props;
+  const { customStyles = {}, staticMode = false } = props;
   const popperId = uuid();
 
   const handleOnKeyDownLeft = (event: KeyboardEvent) => {
@@ -268,6 +277,80 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
     return textFieldProps;
   };
 
+  const renderDay = (day: TDate, _value: TDate[], DayComponentProps: PickersDayProps<TDate>) => {
+    return (
+      <Badge
+        key={(day as unknown as Date).toString()}
+        overlap="circular"
+        variant="standard"
+        color={
+          (DayComponentProps.today && DayComponentProps.selected) ? 'default' : 'primary'
+        }
+        badgeContent={
+          DayComponentProps.today ? <DotMark fontSize="small" /> : undefined
+        }
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        sx={{
+          '& .MuiBadge-badge': {
+            right: '50%',
+            padding: '1px',
+            width: '4px',
+            height: '1px',
+            borderRadius: 'unset',
+            minWidth: '0px',
+            top: '70%',
+            '& .MuiSvgIcon-root': {
+              ...(DayComponentProps.today && DayComponentProps.selected) && {
+                fill: (theme: Theme) => { return theme.palette.common.white; },
+                width: '2px',
+                height: '2px',
+              },
+              ...!(DayComponentProps.today && DayComponentProps.selected) && {
+                fill: 'none',
+                width: '1px',
+                height: '1px',
+              },
+              fontSize: '1px',
+            },
+          },
+        }}
+      >
+        <PickersDay {...DayComponentProps} />
+      </Badge>
+    );
+  };
+  // Static mode - render calendar without input field
+  if (staticMode) {
+    return (
+      <Paper
+        aria-label="Date picker"
+        elevation={8}
+        sx={(theme) => { return getDatePickerStyle(theme, customStyles, true); }}
+      >
+        <MuiStaticDatePicker
+          {...props as unknown as MuiStaticDatePickerProps<TInputDate, TDate>}
+          displayStaticWrapperAs="desktop"
+          reduceAnimations
+          dayOfWeekFormatter={(day) => { return day; }}
+          componentsProps={{
+            actionBar: { actions: ['today'] },
+            leftArrowButton: { onKeyDown: handleOnKeyDownLeft },
+            rightArrowButton: { onKeyDown: handleOnKeyDownRight },
+          }}
+          components={{
+            SwitchViewIcon: CaretDownIcon,
+          }}
+          renderDay={renderDay}
+          renderInput={(_params: MuiTextFieldProps) => { return <span />; }}
+        />
+      </Paper>
+    );
+  }
+
+  // Render regular DatePicker with input field
   return (
     <MuiDatePicker
       {...props}
@@ -297,51 +380,7 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
           <TextField {...textFieldProps} />
         );
       }}
-      renderDay={(day, _value, DayComponentProps) => {
-        return (
-          <Badge
-            key={(day as unknown as Date).toString()}
-            overlap="circular"
-            variant="standard"
-            color={
-              (DayComponentProps.today && DayComponentProps.selected) ? 'default' : 'primary'
-            }
-            badgeContent={
-              DayComponentProps.today ? <DotMark fontSize="small" /> : undefined
-            }
-            anchorOrigin={{
-              vertical: 'bottom',
-              horizontal: 'right',
-            }}
-            sx={{
-              '& .MuiBadge-badge': {
-                right: '50%',
-                padding: '1px',
-                width: '4px',
-                height: '1px',
-                borderRadius: 'unset',
-                minWidth: '0px',
-                top: '70%',
-                '& .MuiSvgIcon-root': {
-                  ...(DayComponentProps.today && DayComponentProps.selected) && {
-                    fill: (theme: Theme) => { return theme.palette.common.white; },
-                    width: '2px',
-                    height: '2px',
-                  },
-                  ...!(DayComponentProps.today && DayComponentProps.selected) && {
-                    fill: 'none',
-                    width: '1px',
-                    height: '1px',
-                  },
-                  fontSize: '1px',
-                },
-              },
-            }}
-          >
-            <PickersDay {...DayComponentProps} />
-          </Badge>
-        );
-      }}
+      renderDay={renderDay}
     />
   );
 };
@@ -363,7 +402,9 @@ DatePicker.defaultProps = {
   nonEdit: false,
   showDaysOutsideCurrentMonth: true,
   error: false,
+  staticMode: false,
 };
 
 export * from '@mui/x-date-pickers/DatePicker';
+export * from '@mui/x-date-pickers/StaticDatePicker';
 export default DatePicker;

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -14,8 +14,8 @@
  * ======================================================================== */
 import React, { KeyboardEvent } from 'react';
 import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatePickerProps } from '@mui/x-date-pickers/DatePicker';
+import { SvgIconProps, Theme } from '@mui/material';
 import { StaticDatePicker as MuiStaticDatePicker, StaticDatePickerProps as MuiStaticDatePickerProps } from '@mui/x-date-pickers/StaticDatePicker';
-import { Paper, SvgIconProps, Theme } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
 import { v4 as uuid } from 'uuid';
 import { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextField';
@@ -23,11 +23,21 @@ import { PickersDay, PickersDayProps } from '@mui/x-date-pickers/PickersDay';
 import DotMark from '@hcl-software/enchanted-icons/dist/carbon/es/dot-mark';
 import IconCalendar from '@hcl-software/enchanted-icons/dist/carbon/es/calendar';
 import CaretDownIcon from '@hcl-software/enchanted-icons/dist/carbon/es/caret--down';
+import Paper from '../Paper';
 import Badge from '../Badge/Badge';
 import { ActionProps } from '../prerequisite_components/InputLabelAndAction/InputLabelAndAction';
 import TextField, { TextFieldProps } from '../TextField';
 
 const DEFAULT_FORMAT: string = 'MM/DD/YYYY';
+
+// Shared formatter used by both static and regular date picker variants
+const dayOfWeekFormatter = (day: string) => { return day; };
+
+// Display mode for the static date picker
+const staticWrapperAs = 'desktop' as const;
+
+// Reduce animations for both static and regular date picker variants
+const shouldReduceAnimations = true;
 
 export interface DatePickerProps<TInputDate, TDate> extends Omit<MuiDatePickerProps<TInputDate, TDate>, 'renderInput'> {
   label?: string;
@@ -325,15 +335,14 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
   if (staticMode) {
     return (
       <Paper
-        aria-label="Date picker"
-        elevation={8}
+        variant="elevation"
         sx={(theme) => { return getDatePickerStyle(theme, customStyles, true); }}
       >
         <MuiStaticDatePicker
           {...props as unknown as MuiStaticDatePickerProps<TInputDate, TDate>}
-          displayStaticWrapperAs="desktop"
-          reduceAnimations
-          dayOfWeekFormatter={(day) => { return day; }}
+          displayStaticWrapperAs={staticWrapperAs}
+          reduceAnimations={shouldReduceAnimations}
+          dayOfWeekFormatter={dayOfWeekFormatter}
           componentsProps={{
             actionBar: { actions: ['today'] },
             leftArrowButton: { onKeyDown: handleOnKeyDownLeft },
@@ -353,10 +362,10 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
   return (
     <MuiDatePicker
       {...props}
-      reduceAnimations
+      reduceAnimations={shouldReduceAnimations}
       autoFocus={false}
       onOpen={focusDialog}
-      dayOfWeekFormatter={(day) => { return day; }}
+      dayOfWeekFormatter={dayOfWeekFormatter}
       PaperProps={{
         sx: (theme) => { return getDatePickerStyle(theme, customStyles); },
       }}
@@ -405,5 +414,4 @@ DatePicker.defaultProps = {
 };
 
 export * from '@mui/x-date-pickers/DatePicker';
-export * from '@mui/x-date-pickers/StaticDatePicker';
 export default DatePicker;

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -23,8 +23,9 @@ import { PickersDay, PickersDayProps } from '@mui/x-date-pickers/PickersDay';
 import DotMark from '@hcl-software/enchanted-icons/dist/carbon/es/dot-mark';
 import IconCalendar from '@hcl-software/enchanted-icons/dist/carbon/es/calendar';
 import CaretDownIcon from '@hcl-software/enchanted-icons/dist/carbon/es/caret--down';
+import { svgIconClasses } from '@mui/material/SvgIcon';
 import Paper from '../Paper';
-import Badge from '../Badge/Badge';
+import Badge, { badgeClasses } from '../Badge/Badge';
 import { ActionProps } from '../prerequisite_components/InputLabelAndAction/InputLabelAndAction';
 import TextField, { TextFieldProps } from '../TextField';
 
@@ -69,7 +70,7 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
     height: 'auto',
     width: '228px',
     color: `1px solid ${theme.palette.background.paper}`,
-    boxShadow: theme.shadows[1],
+    boxShadow: 1,
     '& .MuiPickerStaticWrapper-content': {
       minWidth: 'unset',
     },
@@ -111,7 +112,7 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
     },
     '& .MuiDayPicker-weekDayLabel': {
       ...theme.typography.body2,
-      color: theme.palette.text.secondary,
+      color: 'text.secondary',
       margin: '4px 2px',
       width: '24px',
       padding: '0px',
@@ -126,7 +127,7 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
 
     },
     '& .MuiIconButton-root': {
-      '& .MuiSvgIcon-root': {
+      [`& .${svgIconClasses.root}`]: {
         padding: '0px',
         width: '16px',
         height: '16px',
@@ -155,10 +156,10 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
         position: 'relative',
       },
       '&.MuiPickersDay-dayOutsideMonth': {
-        color: theme.palette.text.disabled,
+        color: 'text.disabled',
       },
       '&:hover': {
-        backgroundColor: theme.palette.action.hover,
+        backgroundColor: 'action.hover',
       },
       '&:focus-visible': {
         backgroundColor: 'transparent',
@@ -166,25 +167,25 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
         outline: `1px solid ${theme.palette.action.focus}`,
         outlineOffset: '3px',
         '&:hover': {
-          backgroundColor: theme.palette.action.hover,
+          backgroundColor: 'action.hover',
           border: 'none',
           outline: `1px solid ${theme.palette.action.focus}`,
           outlineOffset: '3px',
         },
       },
       '&.Mui-selected': {
-        backgroundColor: theme.palette.primary.main,
-        color: theme.palette.text.tertiary1,
+        backgroundColor: 'primary.main',
+        color: 'text.tertiary1',
         '&:hover': {
-          backgroundColor: theme.palette.primary.dark,
+          backgroundColor: 'primary.dark',
         },
         '&:focus-visible': {
-          backgroundColor: theme.palette.primary.main,
+          backgroundColor: 'primary.main',
           border: 'none',
           outline: `1px solid ${theme.palette.action.focus}`,
           outlineOffset: '3px',
           '&:hover': {
-            backgroundColor: theme.palette.primary.dark,
+            backgroundColor: 'primary.dark',
           },
         },
       },
@@ -202,7 +203,7 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
     },
     '& .MuiPickersArrowSwitcher-button': {
       '&:hover': {
-        backgroundColor: theme.palette.action.hover,
+        backgroundColor: 'action.hover',
       },
     },
     ...customStyles,
@@ -351,7 +352,7 @@ const DatePicker = <TInputDate, TDate>({
           horizontal: 'right',
         }}
         sx={{
-          '& .MuiBadge-badge': {
+          [`& .${badgeClasses.badge}`]: {
             right: '50%',
             padding: '1px',
             width: '4px',
@@ -359,9 +360,9 @@ const DatePicker = <TInputDate, TDate>({
             borderRadius: 'unset',
             minWidth: '0px',
             top: '70%',
-            '& .MuiSvgIcon-root': {
+            [`& .${svgIconClasses.root}`]: {
               ...(DayComponentProps.today && DayComponentProps.selected) && {
-                fill: (theme: Theme) => { return theme.palette.common.white; },
+                fill: 'common.white',
                 width: '2px',
                 height: '2px',
               },

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -186,7 +186,6 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
       display: '-webkit-box',
       padding: '12px 0px',
       justifyContent: 'center',
-      borderTop: 'none',
     },
     '& .MuiPickersArrowSwitcher-button': {
       '&:hover': {

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -233,30 +233,29 @@ export const DatePickerDefaults = {
   staticMode: false,
 };
 
-const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate, TDate>) => {
-  const {
-    customStyles = {},
-    staticMode = false,
-    margin = 'none',
-    color = 'primary',
-    size = 'medium',
-    label = '',
-    helperText = '',
-    enableHelpHoverEffect = false,
-    helperIconTooltip = '',
-    format = DEFAULT_FORMAT,
-    unitLabel = '',
-    required = false,
-    disabled = false,
-    fullWidth = false,
-    hiddenLabel = false,
-    nonEdit = false,
-    error = false,
-    actionProps,
-    customIcon,
-    value,
-    ...muiProps
-  } = props;
+const DatePicker = <TInputDate, TDate>({
+  customStyles = {},
+  staticMode = false,
+  margin = 'none',
+  color = 'primary',
+  size = 'medium',
+  label = '',
+  helperText = '',
+  enableHelpHoverEffect = false,
+  helperIconTooltip = '',
+  format = DEFAULT_FORMAT,
+  unitLabel = '',
+  required = false,
+  disabled = false,
+  fullWidth = false,
+  hiddenLabel = false,
+  nonEdit = false,
+  error = false,
+  actionProps,
+  customIcon,
+  value,
+  ...muiProps
+}: DatePickerProps<TInputDate, TDate>) => {
   const popperId = uuid();
 
   const handleOnKeyDownLeft = (event: KeyboardEvent) => {
@@ -296,10 +295,10 @@ const DatePicker = <TInputDate, TDate>({ ...props }: DatePickerProps<TInputDate,
 
   const getTextFieldProps = (muiTextFieldProps: MuiTextFieldProps) => {
     let hasError = false;
-    if (props.value !== null) {
-      const day = props.value as unknown as Dayjs;
+    if (value !== null) {
+      const day = value as unknown as Dayjs;
       if (!Number.isNaN(day.day()) && !Number.isNaN(day.month()) && !Number.isNaN(day.year())) {
-        const valid = dayjs(day, props.format, true).isValid();
+        const valid = dayjs(day, format, true).isValid();
         hasError = !valid;
       }
     }

--- a/src/DatePicker/index.ts
+++ b/src/DatePicker/index.ts
@@ -16,3 +16,4 @@ import DatePicker from './DatePicker';
 
 export default DatePicker;
 export * from './DatePicker';
+export * from '@mui/x-date-pickers/StaticDatePicker';

--- a/src/PickersLocalizationProvider/PickersLocalizationProvider.tsx
+++ b/src/PickersLocalizationProvider/PickersLocalizationProvider.tsx
@@ -156,30 +156,30 @@ const verfiyAdapterLocale = (adapterLocale?: string | object) => {
 };
 
 export type PickersLocalizationProviderProps = MuiLocalizationProviderProps & {
+  onLocaleLoad?: (locale: string) => void;
+  adapterLocale: string | object;
 }
 
-const PickersLocalizationProvider = ({ ...props }: PickersLocalizationProviderProps) => {
+const PickersLocalizationProvider = ({ adapterLocale: adapterLocaleProp = 'en', onLocaleLoad, ...rest }: PickersLocalizationProviderProps) => {
   const [adapterLocale, setAdapterLocale] = useState('en');
   useEffect(() => {
-    if (props.adapterLocale !== undefined && typeof props.adapterLocale === 'string') {
-      const loadDayJsLocale = async (dayJsLocal: string) => {
-        await DAYJS_LOCALE_PACKAGE[dayJsLocal];
-        dayjs.locale(dayJsLocal);
-        setAdapterLocale(dayJsLocal);
+    if (adapterLocaleProp !== undefined && typeof adapterLocaleProp === 'string') {
+      const loadDayJsLocale = async (dayJsLocale: string) => {
+        await DAYJS_LOCALE_PACKAGE[dayJsLocale];
+        dayjs.locale(dayJsLocale);
+        setAdapterLocale(dayJsLocale);
+        onLocaleLoad?.(dayJsLocale);
       };
-      const locale = (props.adapterLocale !== undefined && !SUPPORTED_LOCALE.includes(props.adapterLocale)) ? 'en' : props.adapterLocale;
+      const locale = (!SUPPORTED_LOCALE.includes(adapterLocaleProp)) ? 'en' : adapterLocaleProp;
       loadDayJsLocale(locale);
     }
-  }, [props.adapterLocale]);
+  }, [adapterLocaleProp, onLocaleLoad]);
 
-  verfiyAdapterLocale(props.adapterLocale);
+  verfiyAdapterLocale(adapterLocaleProp);
 
   // Set Monday as the first day of the week in the calendar
   dayjs.Ls[`${adapterLocale}`].weekStart = 1;
-  return <MuiLocalizationProvider {...props} adapterLocale={adapterLocale} localeText={getLocaleText(props.adapterLocale)} />;
-};
-
-PickersLocalizationProvider.defaultProps = {
+  return <MuiLocalizationProvider {...rest} adapterLocale={adapterLocale} localeText={getLocaleText(adapterLocaleProp)} />;
 };
 
 export * from '@mui/x-date-pickers/LocalizationProvider';

--- a/src/PickersLocalizationProvider/PickersLocalizationProvider.tsx
+++ b/src/PickersLocalizationProvider/PickersLocalizationProvider.tsx
@@ -160,7 +160,11 @@ export type PickersLocalizationProviderProps = MuiLocalizationProviderProps & {
   adapterLocale: string | object;
 }
 
-const PickersLocalizationProvider = ({ adapterLocale: adapterLocaleProp = 'en', onLocaleLoad, ...rest }: PickersLocalizationProviderProps) => {
+const PickersLocalizationProvider = ({
+  adapterLocale: adapterLocaleProp = 'en',
+  onLocaleLoad,
+  ...rest
+}: PickersLocalizationProviderProps) => {
   const [adapterLocale, setAdapterLocale] = useState('en');
   useEffect(() => {
     if (adapterLocaleProp !== undefined && typeof adapterLocaleProp === 'string') {

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -365,6 +365,7 @@ const getMuiTextFieldProps = (props: TextFieldProps): OutlinedTextFieldProps => 
   delete cleanedProps.renderNonEditInput;
   delete cleanedProps.endAdornmentAction;
   delete cleanedProps.enableHelpHoverEffect;
+  delete cleanedProps.customIcon;
 
   const muiTextFieldProps: OutlinedTextFieldProps = {
     ...cleanedProps,

--- a/src/__tests__/unit/DatePicker/DatePicker.test.tsx
+++ b/src/__tests__/unit/DatePicker/DatePicker.test.tsx
@@ -15,8 +15,7 @@
 
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ThemeProvider } from '@emotion/react';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs, { Dayjs } from 'dayjs';
@@ -76,13 +75,12 @@ describe('DatePicker staticMode', () => {
     expect(screen.getByRole('button', { name: 'Today' })).toBeInTheDocument();
   });
 
-  it('Render static DatePicker calls onChange with correct dayjs value when a day is clicked', async () => {
+  it('Render static DatePicker calls onChange with correct dayjs value when a day is clicked', () => {
     const handleChange = jest.fn();
     const dateValue = dayjs('2024-01-15');
-    const user = userEvent.setup();
     renderWithProviders(<DatePicker staticMode value={dateValue} onChange={handleChange} />);
-    const date10Button = screen.getByRole('button', { name: '10' });
-    await user.click(date10Button);
+    const date10Button = screen.getByRole('gridcell', { name: '10' });
+    fireEvent.click(date10Button);
     expect(handleChange).toHaveBeenCalledTimes(1);
     const calledWith = handleChange.mock.calls[0][0] as Dayjs;
     expect(dayjs.isDayjs(calledWith)).toBe(true);

--- a/src/__tests__/unit/DatePicker/DatePicker.test.tsx
+++ b/src/__tests__/unit/DatePicker/DatePicker.test.tsx
@@ -14,17 +14,15 @@
  * ======================================================================== */
 
 import React from 'react';
-import {
-  render, screen, cleanup, fireEvent, waitFor,
-} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@emotion/react';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import DatePicker from '../../../DatePicker/DatePicker';
 import PickersLocalizationProvider from '../../../PickersLocalizationProvider/PickersLocalizationProvider';
 import { ThemeDirectionType, ThemeModeType, createEnchantedTheme } from '../../../theme';
-
-afterEach(cleanup);
 
 // Shared render helper — wraps UI in ThemeProvider + PickersLocalizationProvider.
 const renderWithProviders = (ui: React.ReactElement) => {
@@ -41,30 +39,30 @@ describe('DatePicker', () => {
   it('Render regular DatePicker with label', () => {
     const label = 'Date label';
     renderWithProviders(<DatePicker label={label} value={null} onChange={jest.fn()} />);
-    expect(screen.getByText(label)).not.toBeNull();
+    expect(screen.getByText(label)).toBeInTheDocument();
   });
 
   it('Render regular DatePicker with helper text', () => {
     const helperText = 'Pick a date';
     renderWithProviders(<DatePicker helperText={helperText} value={null} onChange={jest.fn()} />);
-    expect(screen.getByText(helperText)).not.toBeNull();
+    expect(screen.getByText(helperText)).toBeInTheDocument();
   });
 
   it('Render regular DatePicker as disabled sets disabled property on input', () => {
     renderWithProviders(<DatePicker disabled value={null} onChange={jest.fn()} />);
-    expect(screen.getByRole('textbox')).toHaveProperty('disabled', true);
+    expect(screen.getByRole('textbox')).toBeDisabled();
   });
 
   it('Render regular DatePicker renders a text input field', () => {
     renderWithProviders(<DatePicker value={null} onChange={jest.fn()} />);
-    expect(screen.getByRole('textbox')).not.toBeNull();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
   });
 });
 
 describe('DatePicker staticMode', () => {
   it('Render static DatePicker does not render a text input field', () => {
     renderWithProviders(<DatePicker staticMode value={null} onChange={jest.fn()} />);
-    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
   it('Render static DatePicker renders calendar day buttons', () => {
@@ -75,17 +73,20 @@ describe('DatePicker staticMode', () => {
 
   it('Render static DatePicker shows the Today button in action bar', () => {
     renderWithProviders(<DatePicker staticMode value={null} onChange={jest.fn()} />);
-    expect(screen.getByText('Today')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Today' })).toBeInTheDocument();
   });
 
-  it('Render static DatePicker calls onChange when a day is clicked', async () => {
+  it('Render static DatePicker calls onChange with correct dayjs value when a day is clicked', async () => {
     const handleChange = jest.fn();
     const dateValue = dayjs('2024-01-15');
+    const user = userEvent.setup();
     renderWithProviders(<DatePicker staticMode value={dateValue} onChange={handleChange} />);
-    fireEvent.click(screen.getByText('10'));
-    await waitFor(() => {
-      expect(handleChange).toHaveBeenCalled();
-    });
+    const date10Button = screen.getByRole('button', { name: '10' });
+    await user.click(date10Button);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    const calledWith = handleChange.mock.calls[0][0] as Dayjs;
+    expect(dayjs.isDayjs(calledWith)).toBe(true);
+    expect(calledWith.format('YYYY-MM-DD')).toBe('2024-01-10');
   });
 
   it('Render static DatePicker with disabled prop applies Mui-disabled class', () => {
@@ -93,7 +94,7 @@ describe('DatePicker staticMode', () => {
     const { container } = renderWithProviders(
       <DatePicker staticMode disabled value={dateValue} onChange={jest.fn()} />,
     );
-    expect(container.querySelector('.Mui-disabled')).not.toBeNull();
+    expect(container.querySelector('.Mui-disabled')).toBeInTheDocument();
   });
 
   it('Render static DatePicker wrapped in Paper with elevation variant', () => {
@@ -102,7 +103,7 @@ describe('DatePicker staticMode', () => {
       <DatePicker staticMode value={dateValue} onChange={jest.fn()} />,
     );
     const paperEl = container.querySelector('.MuiPaper-root');
-    expect(paperEl).not.toBeNull();
+    expect(paperEl).toBeInTheDocument();
     expect(paperEl?.classList.contains('MuiPaper-elevation')).toBe(true);
   });
 });

--- a/src/__tests__/unit/DatePicker/DatePicker.test.tsx
+++ b/src/__tests__/unit/DatePicker/DatePicker.test.tsx
@@ -1,0 +1,113 @@
+/* ======================================================================== *
+ * Copyright 2026 HCL America Inc.                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ * http://www.apache.org/licenses/LICENSE-2.0                               *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ * ======================================================================== */
+
+import React from 'react';
+import {
+  render, screen, cleanup, fireEvent, waitFor,
+} from '@testing-library/react';
+import { ThemeProvider } from '@emotion/react';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs from 'dayjs';
+import DatePicker from '../../../DatePicker/DatePicker';
+import PickersLocalizationProvider from '../../../PickersLocalizationProvider/PickersLocalizationProvider';
+import { ThemeDirectionType, ThemeModeType, createEnchantedTheme } from '../../../theme';
+
+afterEach(cleanup);
+
+/**
+ * Wraps the given UI in the theme and localisation providers required by
+ * every DatePicker test, eliminating the repeated boilerplate.
+ */
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(
+    <ThemeProvider theme={createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY)}>
+      <PickersLocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="en">
+        {ui}
+      </PickersLocalizationProvider>
+    </ThemeProvider>,
+  );
+};
+
+describe('DatePicker', () => {
+  it('Render regular DatePicker with label', () => {
+    const label = 'Date label';
+    renderWithProviders(<DatePicker label={label} value={null} onChange={jest.fn()} />);
+    expect(screen.getByText(label)).not.toBeNull();
+  });
+
+  it('Render regular DatePicker with helper text', () => {
+    const helperText = 'Pick a date';
+    renderWithProviders(<DatePicker helperText={helperText} value={null} onChange={jest.fn()} />);
+    expect(screen.getByText(helperText)).not.toBeNull();
+  });
+
+  it('Render regular DatePicker as disabled sets disabled property on input', () => {
+    renderWithProviders(<DatePicker disabled value={null} onChange={jest.fn()} />);
+    expect(screen.getByRole('textbox')).toHaveProperty('disabled', true);
+  });
+
+  it('Render regular DatePicker renders a text input field', () => {
+    renderWithProviders(<DatePicker value={null} onChange={jest.fn()} />);
+    expect(screen.getByRole('textbox')).not.toBeNull();
+  });
+});
+
+describe('DatePicker staticMode', () => {
+  it('Render static DatePicker does not render a text input field', () => {
+    renderWithProviders(<DatePicker staticMode value={null} onChange={jest.fn()} />);
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('Render static DatePicker renders calendar day buttons', () => {
+    const dateValue = dayjs('2024-01-15');
+    const { getAllByRole } = renderWithProviders(
+      <DatePicker staticMode value={dateValue} onChange={jest.fn()} />,
+    );
+    expect(getAllByRole('button').length).toBeGreaterThan(0);
+  });
+
+  it('Render static DatePicker shows the Today button in action bar', () => {
+    renderWithProviders(<DatePicker staticMode value={null} onChange={jest.fn()} />);
+    expect(screen.getByText('Today')).not.toBeNull();
+  });
+
+  it('Render static DatePicker calls onChange when a day is clicked', async () => {
+    const handleChange = jest.fn();
+    const dateValue = dayjs('2024-01-15');
+    renderWithProviders(<DatePicker staticMode value={dateValue} onChange={handleChange} />);
+    fireEvent.click(screen.getByText('10'));
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalled();
+    });
+  });
+
+  it('Render static DatePicker with disabled prop applies Mui-disabled class', () => {
+    const dateValue = dayjs('2024-01-15');
+    const { container } = renderWithProviders(
+      <DatePicker staticMode disabled value={dateValue} onChange={jest.fn()} />,
+    );
+    expect(container.querySelector('.Mui-disabled')).not.toBeNull();
+  });
+
+  it('Render static DatePicker wrapped in Paper with elevation variant', () => {
+    const dateValue = dayjs('2024-01-15');
+    const { container } = renderWithProviders(
+      <DatePicker staticMode value={dateValue} onChange={jest.fn()} />,
+    );
+    const paperEl = container.querySelector('.MuiPaper-root');
+    expect(paperEl).not.toBeNull();
+    expect(paperEl?.classList.contains('MuiPaper-elevation')).toBe(true);
+  });
+});

--- a/src/__tests__/unit/DatePicker/DatePicker.test.tsx
+++ b/src/__tests__/unit/DatePicker/DatePicker.test.tsx
@@ -26,10 +26,7 @@ import { ThemeDirectionType, ThemeModeType, createEnchantedTheme } from '../../.
 
 afterEach(cleanup);
 
-/**
- * Wraps the given UI in the theme and localisation providers required by
- * every DatePicker test, eliminating the repeated boilerplate.
- */
+// Shared render helper — wraps UI in ThemeProvider + PickersLocalizationProvider.
 const renderWithProviders = (ui: React.ReactElement) => {
   return render(
     <ThemeProvider theme={createEnchantedTheme(ThemeDirectionType.LTR, ThemeModeType.LIGHT_NEUTRAL_GREY)}>
@@ -72,10 +69,8 @@ describe('DatePicker staticMode', () => {
 
   it('Render static DatePicker renders calendar day buttons', () => {
     const dateValue = dayjs('2024-01-15');
-    const { getAllByRole } = renderWithProviders(
-      <DatePicker staticMode value={dateValue} onChange={jest.fn()} />,
-    );
-    expect(getAllByRole('button').length).toBeGreaterThan(0);
+    renderWithProviders(<DatePicker staticMode value={dateValue} onChange={jest.fn()} />);
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
   });
 
   it('Render static DatePicker shows the Today button in action bar', () => {


### PR DESCRIPTION
This PR adds a Static DatePicker variant to the existing DatePicker component.
Unlike the standard DatePicker, the static version renders a direct calendar view without an input field, making it useful for scenarios where inline date selection is preferred.

<img width="1277" height="849" alt="image" src="https://github.com/user-attachments/assets/0acd4d97-36bf-4dab-9355-5a01767637ca" />
