### PR TITLE
update @mui/material, @mui/system, lodash, fix types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Switch to the last @hcl-software/enchanted-icons package
 - Extends the IconPreview with new icons
 - Fix MultipleSelectChip broken layout caused by startAdornment wrapping chips in InputAdornment
+- Updates @mui/material and @mui/system packages to the latest available v5 version
+  - Fix resulting type errors in Select.tsx and Tabs.tsx
 
 ### Breaking changes
 
@@ -38,7 +40,7 @@
 
 ### Fixed
 - Fixed ref forwarding support for the `ListItem` component, allowing access to the underlying DOM element.
-- Fixed the issue where the `Autocomplete` tooltip was overwritten by transient input.  
+- Fixed the issue where the `Autocomplete` tooltip was overwritten by transient input.
 - Fixed the issue where the `Autocomplete` text was truncating prematurely (ellipses) despite having available space.
 
 ## 2.3.0
@@ -134,7 +136,7 @@
 - Fixed screen reader accessibility issue with the zoom in & zoom out `button` in the `Preview` component.
 - Fixed focus handling on the expand/collapse icon button in the `ProgressBar` component to address accessibility issues
 - Fixed screen reader accessibility issue with the `label` in `Select` component
-- Added `component` props in `Typography`. 
+- Added `component` props in `Typography`.
 - Fixed focus issue for different status icon buttons in the `ProgressBar` component
 - Fixed button height to align with design specifications
 - Fixed Text spacing accessibility issue on `Pagination` component
@@ -187,7 +189,7 @@
 - corrected the hex value for HCLSOFTWAREBLUE06 to #003CE6
 
 ### Changed
-- Added hasThumbnail and disabled properties to the Tile component. 
+- Added hasThumbnail and disabled properties to the Tile component.
 - Added as hover image preview icon for the Tile component.
 - Adding props for error handling in Preview component.
 - Adding handleClick, disabled and tooltip to the ActionProps interface in the InputLabelAndAction component.
@@ -206,8 +208,8 @@
 - Updated breadcrumb icons to reflect directionality (RTL/LTR)
 - Resolved spacing issues for icon buttons in the panel component.
 - Updated Tooltip title type with React.ReactNode from string so as to accept string as well as html node.
-- Added `isRowClickable` prop to the `DataGrid` component. 
-- Added `tooltipPlacement` prop to the `MultipleSelectChip`, `Autocomplete` and `Panel` component. 
+- Added `isRowClickable` prop to the `DataGrid` component.
+- Added `tooltipPlacement` prop to the `MultipleSelectChip`, `Autocomplete` and `Panel` component.
 - Updated icon button spacing in Snackbar
 - Adjusted checkbox alignment in `DataGrid` component
 - Resolved tooltip issue of options in `Autocomplete` component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 - Switch to the last @hcl-software/enchanted-icons package
 - Extends the IconPreview with new icons
 - Fix MultipleSelectChip broken layout caused by startAdornment wrapping chips in InputAdornment
-- Updates @mui/material and @mui/system packages to the latest available v5 version
+- Updates @mui/material and @mui/system packages to the latest available v5 version, 5.18.0
   - Fix resulting type errors in Select.tsx and Tabs.tsx
+- Updates lodash package to the latest version, 4.18.1
 
 ### Breaking changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@mui/x-date-pickers": "5.0.4",
         "dayjs": "^1.11.10",
         "jest-reporter-log-validator": "^0.1.6",
-        "lodash": "^4.17.15",
+        "lodash": "^4.18.1",
         "stylis-plugin-rtl": "^2.1.1",
         "uuid": "^8.3.0"
       },
@@ -16324,9 +16324,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "@emotion/styled": "^11.11.5",
         "@hcl-software/enchanted-icons": "^1.9.0",
         "@mui/lab": "5.0.0-alpha.103",
-        "@mui/material": "5.10.10",
-        "@mui/system": "5.15.13",
+        "@mui/material": "5.18.0",
+        "@mui/system": "5.18.0",
         "@mui/x-data-grid": "5.17.8",
         "@mui/x-date-pickers": "5.0.4",
         "dayjs": "^1.11.10",
@@ -70,7 +70,7 @@
         "webpack": "^5.89.0"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2253,16 +2253,29 @@
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/@emotion/cache": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
-      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
       "dependencies": {
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/sheet": "^1.2.2",
-        "@emotion/utils": "^1.2.1",
-        "@emotion/weak-memoize": "^0.3.1",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
         "stylis": "4.2.0"
       }
+    },
+    "node_modules/@emotion/cache/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/cache/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@emotion/cache/node_modules/stylis": {
       "version": "4.2.0",
@@ -2270,9 +2283,10 @@
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/@emotion/hash": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
@@ -2311,21 +2325,29 @@
       }
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.4.tgz",
-      "integrity": "sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
       "dependencies": {
-        "@emotion/hash": "^0.9.1",
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/unitless": "^0.8.1",
-        "@emotion/utils": "^1.2.1",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@emotion/serialize/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
     "node_modules/@emotion/sheet": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
     },
     "node_modules/@emotion/styled": {
       "version": "11.11.5",
@@ -2350,9 +2372,10 @@
       }
     },
     "node_modules/@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
@@ -2363,9 +2386,10 @@
       }
     },
     "node_modules/@emotion/utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.3.1",
@@ -3563,9 +3587,10 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.15.15",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.15.tgz",
-      "integrity": "sha512-aXnw29OWQ6I5A47iuWEI6qSSUfH6G/aCsW9KmW3LiFqr7uXZBK4Ks+z8G+qeIub8k0T5CMqlT2q0L+ZJTMrqpg==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
+      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
@@ -3613,21 +3638,22 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.10.10",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.10.10.tgz",
-      "integrity": "sha512-ioLvqY7VvcePz9dnEIRhpiVvtJmAFmvG6rtLXXzVdMmAVbSaelr5Io07mPz/mCyqE+Uv8/4EuJV276DWO7etzA==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
+      "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@mui/base": "5.0.0-alpha.102",
-        "@mui/core-downloads-tracker": "^5.10.10",
-        "@mui/system": "^5.10.10",
-        "@mui/types": "^7.2.0",
-        "@mui/utils": "^5.10.9",
-        "@types/react-transition-group": "^4.4.5",
-        "clsx": "^1.2.1",
-        "csstype": "^3.1.1",
+        "@babel/runtime": "^7.23.9",
+        "@mui/core-downloads-tracker": "^5.18.0",
+        "@mui/system": "^5.18.0",
+        "@mui/types": "~7.2.15",
+        "@mui/utils": "^5.17.1",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
-        "react-is": "^18.2.0",
+        "react-is": "^19.0.0",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -3635,14 +3661,14 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -3656,45 +3682,29 @@
         }
       }
     },
-    "node_modules/@mui/material/node_modules/@mui/base": {
-      "version": "5.0.0-alpha.102",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.102.tgz",
-      "integrity": "sha512-5e/qAIP+DlkrZxIt/cwnDw/A3ii22WkoEoWKHyu4+oeGs3/1Flh7qLaN4h5EAIBB9TvTEZEUzvmsTInmIj6ghg==",
-      "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "@mui/types": "^7.2.0",
-        "@mui/utils": "^5.10.9",
-        "@popperjs/core": "^2.11.6",
-        "clsx": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
-      },
+    "node_modules/@mui/material/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
+        "node": ">=6"
       }
     },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT"
+    },
     "node_modules/@mui/private-theming": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.14.tgz",
-      "integrity": "sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
+      "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.15.14",
+        "@mui/utils": "^5.17.1",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3705,8 +3715,8 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3715,12 +3725,14 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.14.tgz",
-      "integrity": "sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
+      "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@emotion/cache": "^11.11.0",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
@@ -3734,7 +3746,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.4.1",
         "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -3746,15 +3758,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.15.13",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.13.tgz",
-      "integrity": "sha512-eHaX3sniZXNWkxX0lmcLxROhQ5La0HkOuF7zxbSdAoHUOk07gboQYmF6hSJ/VBFx/GLanIw67FMTn88vc8niLg==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
+      "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.15.13",
-        "@mui/styled-engine": "^5.15.11",
-        "@mui/types": "^7.2.13",
-        "@mui/utils": "^5.15.13",
+        "@mui/private-theming": "^5.17.1",
+        "@mui/styled-engine": "^5.18.0",
+        "@mui/types": "~7.2.15",
+        "@mui/utils": "^5.17.1",
         "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -3769,8 +3782,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -3793,11 +3806,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.14",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.14.tgz",
-      "integrity": "sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==",
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+      "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3806,14 +3820,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.14.tgz",
-      "integrity": "sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
+      "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@types/prop-types": "^15.7.11",
+        "@mui/types": "~7.2.15",
+        "@types/prop-types": "^15.7.12",
+        "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
+        "react-is": "^19.0.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3823,14 +3840,29 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
           "optional": true
         }
       }
+    },
+    "node_modules/@mui/utils/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT"
     },
     "node_modules/@mui/x-data-grid": {
       "version": "5.17.8",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@mui/x-date-pickers": "5.0.4",
     "dayjs": "^1.11.10",
     "jest-reporter-log-validator": "^0.1.6",
-    "lodash": "^4.17.15",
+    "lodash": "^4.18.1",
     "stylis-plugin-rtl": "^2.1.1",
     "uuid": "^8.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "@emotion/styled": "^11.11.5",
     "@hcl-software/enchanted-icons": "^1.9.0",
     "@mui/lab": "5.0.0-alpha.103",
-    "@mui/material": "5.10.10",
-    "@mui/system": "5.15.13",
+    "@mui/material": "5.18.0",
+    "@mui/system": "5.18.0",
     "@mui/x-data-grid": "5.17.8",
     "@mui/x-date-pickers": "5.0.4",
     "dayjs": "^1.11.10",
@@ -100,7 +100,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0"
   },
   "overrides": {
     "stylis-plugin-rtl": {

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -406,7 +406,7 @@ export const getMuiAutocompleteThemeOverrides = (): Components<Omit<Theme, 'comp
                   '.MuiAutocomplete-endAdornment': { // end icon
                     right: '8px',
                     '.MuiButtonBase-root': { // for both clear icon and caret down icon
-                      top: '3px',
+                      top: '-1px',
                       // eslint-why - a nested ternary is needed
                       // eslint-disable-next-line no-nested-ternary
                       margin: ownerState.error ? (ownerState.freeSolo ? '0px 30px 0px 4px' : '0px 36px 0px 4px') : '0px 6px 0px 4px',

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -30,7 +30,7 @@ import Typography from '../Typography';
 import InputLabelAndAction, { ActionProps, InputLabelAndActionProps } from '../prerequisite_components/InputLabelAndAction';
 import { ThemeDirectionType } from '../theme';
 
-export interface SelectProps extends MuiSelectProps {
+export type SelectProps = MuiSelectProps & {
   nonEdit?: boolean;
   actionProps?: ActionProps[];
   helperText?: string;
@@ -44,7 +44,10 @@ export interface SelectProps extends MuiSelectProps {
   hiddenLabel?: boolean,
   value?: string,
   customIcon?: React.ComponentType<SvgIconProps> | undefined;
-}
+  label?: string;
+  placeholder?: string;
+  children?: React.ReactNode;
+};
 
 export const getMuiSelectThemeOverrides = (): Components<Omit<Theme, 'components'>> => {
   return {
@@ -219,7 +222,7 @@ const renderInput = (props: SelectProps, id?: string) => {
         PaperProps: {
           style: paperPropsStyle,
           elevation: 2,
-          ref: (node) => {
+          ref: (node: HTMLDivElement | null) => {
             if (node && props.fullWidth && props.id) {
               // Dynamically set the Paper width to match the Select input width
               const selectElement = document.getElementById(props.id)?.parentElement;

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -18,6 +18,7 @@ import MuiTabs, { TabsProps as MuiTabsProps } from '@mui/material/Tabs';
 import { styled } from '@mui/material/styles';
 
 interface TabsProps extends MuiTabsProps {
+  disabled?: boolean;
   iconposition?: 'start' | 'top';
   showIcon?: boolean;
   showLabel?: boolean;
@@ -57,7 +58,7 @@ const StyledTabs = styled(MuiTabs)((props) => {
 const Tabs = ({ ...props }: TabsProps) => {
   const [value, setValue] = useState(props.value || 0);
   const [indicatorStyle, setIndicatorStyle] = useState({});
-  const tabsRef = useRef<HTMLButtonElement | null>(null);
+  const tabsRef = useRef<HTMLDivElement | null>(null);
 
   /**
   * This function calculates and updates the style of the tab indicator. It determines the orientation of the tabs,

--- a/src/__tests__/unit/Pagination/Pagination.test.tsx
+++ b/src/__tests__/unit/Pagination/Pagination.test.tsx
@@ -89,7 +89,7 @@ describe('TablePagination', () => {
 
     const element = screen.getAllByRole('combobox')[0];
     fireEvent.mouseDown(element);
-    const listbox = within(screen.getAllByRole('listbox')[2]);
+    const listbox = within(screen.getByRole('listbox'));
     expect(listbox.getByText('25')).not.toBeNull();
     fireEvent.click(listbox.getByText('25'));
     await waitFor(() => { expect(mockFn).toHaveBeenCalled(); });
@@ -104,7 +104,7 @@ describe('TablePagination', () => {
       </ThemeProvider>,
     );
 
-    const element = screen.getAllByRole('combobox')[1];
+    const element = screen.getAllByRole('combobox')[2];
     fireEvent.mouseDown(element);
     const listbox = within(screen.getAllByRole('listbox')[2]);
     expect(listbox.getByText('5')).not.toBeNull();

--- a/src/__tests__/unit/Select/Select.test.tsx
+++ b/src/__tests__/unit/Select/Select.test.tsx
@@ -177,7 +177,7 @@ describe('Select', () => {
     );
     // verify menu not present
     expect(screen.queryByRole('listbox')).toBeNull();
-    const select = getByRole('button', { name: /My Label\s*/ });
+    const select = getByRole('combobox', { name: /My Label\s*/ });
     const user = userEvent.setup();
     await act(async () => {
       await user.click(select);


### PR DESCRIPTION
Update @mui/material@5.10.10 and @mui/system@5.15.13 to the latest v5, 5.18.0. That also required updating the peer dependency of "react": "^18.2.0 || ^19.0.0". npm install wouldn’t run cleanly without updating the react peer dependency, even though it still uses 18.2.0 in its build.

```
$ npm ls react
@hcl-software/enchanted-react-components@2.4.0 /Users/danielmanning/pgit/HCL-TECH-SOFTWARE/enchanted-react-components
├─┬ @emotion/react@11.11.4
│ ├─┬ @emotion/use-insertion-effect-with-fallbacks@1.0.1
│ │ └── react@18.2.0 deduped
│ └── react@18.2.0 deduped
├─┬ @emotion/styled@11.11.5
│ └── react@18.2.0 deduped
...
```

Also fixes build type errors in Select.tsx and Tabs.tsx post-upgrade.

Also updates lodash to latest 4.18.1.