### PR TITLE
fixed the blue border issue in the datagrid when clicked on cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+- Fixed unwanted blue border appearing on `DataGrid` cells when clicked with mouse by using `:focus-visible` to distinguish between mouse and keyboard focus
 
 ### Changed
 - Switch to the last @hcl-software/enchanted-icons package

--- a/src/DataGrid/DataGrid.tsx
+++ b/src/DataGrid/DataGrid.tsx
@@ -142,6 +142,9 @@ const StyledDataGrid = styled(MuiDataGrid)<DataGridProps>((props) => {
       },
     },
     '& .MuiDataGrid-cell:focus': {
+      outline: 'none',
+    },
+    '& .MuiDataGrid-cell:focus-visible': {
       border: `1px ${theme.palette.action.focus} solid`,
       outline: 'none',
     },
@@ -241,6 +244,9 @@ const StyledDataGrid = styled(MuiDataGrid)<DataGridProps>((props) => {
       borderBottom: `1px ${theme.palette.action.activeOpacity} solid !important`, // need to be important so border bottom will not primary when it is a checkbox cell
     },
     '& .MuiDataGrid-cell:focus-within': {
+      outline: 'none',
+    },
+    '& .MuiDataGrid-cell:has(:focus-visible)': {
       outline: 'none',
       border: `1px ${theme.palette.action.focus} solid`,
       borderBottom: `1px ${theme.palette.action.focus} solid !important`, // need to be important to override data grid border bottom behaviour when focused


### PR DESCRIPTION
https://hclsw-jirads.atlassian.net/browse/DXQ-48134
Issue:- A blue border appears on a datagrid cell when the cell is clicked.

Fix:-  Fixed unwanted blue border appearing on `DataGrid` cells when clicked with mouse by using `:focus-visible` to distinguish between mouse and keyboard focus
