### PR TITLE
DXQ-48869 - DAM: Can not add a keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Fixed unwanted blue border appearing on `DataGrid` cells when clicked with mouse by using `:focus-visible` to distinguish between mouse and keyboard focus
+- Fixed autocomplete onChange function always passing 'selectOption' as reason
 
 ### Changed
 - Switch to the last @hcl-software/enchanted-icons package

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -14,7 +14,7 @@
  * ======================================================================== */
 
 import React from 'react';
-import MuiAutocomplete, { AutocompleteInputChangeReason, AutocompleteProps as MuiAutocompleteProps } from '@mui/material/Autocomplete';
+import MuiAutocomplete, { AutocompleteChangeDetails, AutocompleteChangeReason, AutocompleteInputChangeReason, AutocompleteProps as MuiAutocompleteProps } from '@mui/material/Autocomplete';
 import {
   Components, InputAdornment, SvgIconProps, Theme,
 } from '@mui/material';
@@ -192,7 +192,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
     return Math.max(iconWidth, 0);
   }, [props.endAdornment, props.error, props.freeSolo, props.disabled, textfieldRef]);
 
-  const handleChange = (event: React.SyntheticEvent<Element, Event>, value: T | NonNullable<string | T> | (string | T)[] | null) => {
+  const handleChange = (event: React.SyntheticEvent<Element, Event>, value: T | NonNullable<string | T> | (string | T)[] | null, reason: AutocompleteChangeReason, details?: AutocompleteChangeDetails<T>) => {
     // Value can be an option from the list or null if cleared
     setSelectedOption(value as T | null);
     if (textfieldRef.current) {
@@ -201,7 +201,7 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
 
     // Call the existing onChange from props if it exists
     if (rest.onChange) {
-      rest.onChange(event, value, 'selectOption');
+      rest.onChange(event, value, reason, details);
     }
   };
 

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -14,7 +14,9 @@
  * ======================================================================== */
 
 import React from 'react';
-import MuiAutocomplete, { AutocompleteChangeDetails, AutocompleteChangeReason, AutocompleteInputChangeReason, AutocompleteProps as MuiAutocompleteProps } from '@mui/material/Autocomplete';
+import MuiAutocomplete, {
+  AutocompleteChangeDetails, AutocompleteChangeReason, AutocompleteInputChangeReason, AutocompleteProps as MuiAutocompleteProps,
+} from '@mui/material/Autocomplete';
 import {
   Components, InputAdornment, SvgIconProps, Theme,
 } from '@mui/material';
@@ -192,7 +194,12 @@ const Autocomplete = <T, Multiple extends boolean | undefined = undefined,
     return Math.max(iconWidth, 0);
   }, [props.endAdornment, props.error, props.freeSolo, props.disabled, textfieldRef]);
 
-  const handleChange = (event: React.SyntheticEvent<Element, Event>, value: T | NonNullable<string | T> | (string | T)[] | null, reason: AutocompleteChangeReason, details?: AutocompleteChangeDetails<T>) => {
+  const handleChange = (
+    event: React.SyntheticEvent<Element, Event>,
+    value: T | NonNullable<string | T> | (string | T)[] | null,
+    reason: AutocompleteChangeReason,
+    details?: AutocompleteChangeDetails<T>,
+  ) => {
     // Value can be an option from the list or null if cleared
     setSelectedOption(value as T | null);
     if (textfieldRef.current) {


### PR DESCRIPTION
### Jira Link: https://hclsw-jirads.atlassian.net/browse/DXQ-48869

**Description**
The onChange function of AutoComplete is always passing 'selectOption' as reason - causing issue on MultipleSelectChip (createOption, clear) reasons.