### PR TITLE
reverted blue border fix in datagrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+- Reverted `DataGrid` focus-visible changes as the fix was breaking accessibility standards - blue border now appears on all cell focus (both mouse and keyboard) for consistency
 
 ### Changed
 

--- a/src/DataGrid/DataGrid.tsx
+++ b/src/DataGrid/DataGrid.tsx
@@ -142,9 +142,6 @@ const StyledDataGrid = styled(MuiDataGrid)<DataGridProps>((props) => {
       },
     },
     '& .MuiDataGrid-cell:focus': {
-      outline: 'none',
-    },
-    '& .MuiDataGrid-cell:focus-visible': {
       border: `1px ${theme.palette.action.focus} solid`,
       outline: 'none',
     },
@@ -244,9 +241,6 @@ const StyledDataGrid = styled(MuiDataGrid)<DataGridProps>((props) => {
       borderBottom: `1px ${theme.palette.action.activeOpacity} solid !important`, // need to be important so border bottom will not primary when it is a checkbox cell
     },
     '& .MuiDataGrid-cell:focus-within': {
-      outline: 'none',
-    },
-    '& .MuiDataGrid-cell:has(:focus-visible)': {
       outline: 'none',
       border: `1px ${theme.palette.action.focus} solid`,
       borderBottom: `1px ${theme.palette.action.focus} solid !important`, // need to be important to override data grid border bottom behaviour when focused


### PR DESCRIPTION
Issue:- The fix introduced in the PR was breaking accessibility standards, as confirmed by the COE accessibility team.
https://github.com/HCL-TECH-SOFTWARE/enchanted-react-components/pull/373

Fix:- Reverted the focus-visible changes to restore the original focus behavior where the blue border appears on all cell focus events (both mouse and keyboard)