### PR TITLE
Fix StaticDatePicker Year Grid Keyboard Navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Reverted `DataGrid` focus-visible changes as the fix was breaking accessibility standards - blue border now appears on all cell focus (both mouse and keyboard) for consistency
+- Fixed StaticDatePicker year grid keyboard navigation: up/down arrows now move vertically in the same column. Set `displayStaticWrapperAs='mobile'`, `showToolbar={false}`, and `closeOnSelect={false}` for correct layout and UX.
 
 ### Changed
 

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -35,7 +35,7 @@ const DEFAULT_FORMAT: string = 'MM/DD/YYYY';
 const dayOfWeekFormatter = (day: string) => { return day; };
 
 // Display mode for the static date picker
-const staticWrapperAs = 'desktop' as const;
+const staticWrapperAs = 'mobile' as const;
 
 export interface DatePickerProps<TInputDate, TDate> extends Omit<MuiDatePickerProps<TInputDate, TDate>, 'renderInput'> {
   label?: string;
@@ -392,6 +392,8 @@ const DatePicker = <TInputDate, TDate>({
           disabled={disabled}
           value={value}
           displayStaticWrapperAs={staticWrapperAs}
+          closeOnSelect={false}
+          showToolbar={false}
           reduceAnimations
           dayOfWeekFormatter={dayOfWeekFormatter}
           componentsProps={{

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -37,6 +37,11 @@ const dayOfWeekFormatter = (day: string) => { return day; };
 // Display mode for the static date picker
 const staticWrapperAs = 'mobile' as const;
 
+// Number of year columns rendered in the year picker view.
+// Must match `yearsInRow` used by MUI internally (set via displayStaticWrapperAs='mobile' for StaticDatePicker).
+// Also used by handleYearPickerKeyDown to correct arrow-key navigation for the non-static DatePicker.
+const YEARS_PER_ROW = 3;
+
 export interface DatePickerProps<TInputDate, TDate> extends Omit<MuiDatePickerProps<TInputDate, TDate>, 'renderInput'> {
   label?: string;
   helperText?: string;
@@ -84,6 +89,16 @@ const getDatePickerStyle = (theme: Theme, customStyles: React.CSSProperties | { 
     '& .MuiYearPicker-root': {
       maxHeight: '168px',
       overflowY: 'auto',
+    },
+    // Assumes year view displays 3 years across.
+    // Requires `displayStaticWrapperAs: 'mobile'` to set
+    // `yearsInRow = 3` for arrow key navigation.
+    '& .PrivatePickersYear-root': {
+      flexBasis: '33.33%',
+    },
+    '& .PrivatePickersYear-yearButton': {
+      width: '100%',
+      maxWidth: 'unset',
     },
     '& .MuiTouchRipple-root': {
       color: 'transparent',
@@ -280,6 +295,33 @@ const DatePicker = <TInputDate, TDate>({
   const formatValue = (dateValue: Dayjs, dateFormat: string): string => {
     return dateValue.format(dateFormat);
   };
+
+  /**
+   * Corrects Up/Down arrow key navigation in the year picker for the non-static DatePicker.
+   * MUI v5 desktop mode hard-codes yearsInRow=4, but our CSS renders 3 columns.
+   * This intercepts the event before MUI handles it and manually moves focus by 3
+   * to match the visual row layout, preventing diagonal jumps.
+   */
+  const handleYearPickerKeyDown = (event: KeyboardEvent) => {
+    const target = event.target as HTMLElement;
+    if (!target.classList.contains('PrivatePickersYear-yearButton')) return;
+    if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const yearButtons = Array.from(
+      document.querySelectorAll<HTMLElement>('.PrivatePickersYear-yearButton:not([disabled])'),
+    );
+    const currentIndex = yearButtons.indexOf(target);
+    if (currentIndex === -1) return;
+
+    const nextIndex = event.key === 'ArrowDown' ? currentIndex + YEARS_PER_ROW : currentIndex - YEARS_PER_ROW;
+    if (nextIndex >= 0 && nextIndex < yearButtons.length) {
+      yearButtons[nextIndex].focus();
+    }
+  };
+
   const focusDialog = () => {
     window.requestAnimationFrame(() => {
       const dialog = document.querySelector(`#datepickerPopper-${popperId}`) ?? document.querySelector('.MuiPickersPopper-root');
@@ -423,6 +465,7 @@ const DatePicker = <TInputDate, TDate>({
       dayOfWeekFormatter={dayOfWeekFormatter}
       PaperProps={{
         sx: (theme) => { return getDatePickerStyle(theme, customStyles); },
+        onKeyDownCapture: handleYearPickerKeyDown,
       }}
       PopperProps={{
         placement: 'bottom-start',


### PR DESCRIPTION
**Issue:**  
In the StaticDatePicker year dropdown, pressing up/down arrows moved focus diagonally instead of vertically. This broke accessibility and keyboard usability.

**Root Cause:**
- MUI defaults to a 4‑column year grid (displayStaticWrapperAs='desktop).
- Enchanted constrains width to 228px, which renders 3 columns.
- Keyboard handler assumed 4 columns, causing diagonal jumps.

**Before Fix:** 
https://github.com/user-attachments/assets/a07f7609-d402-4d3b-bccf-4e68dd052159


**Fix / Solution :**

Props added to StaticDatePicker:
1. displayStaticWrapperAs='mobile' → Forces MUI to use a 3‑column year grid, matching the visual layout at 228px width.
2. closeOnSelect={false} → Keeps the dropdown open after selecting a year, allowing continued keyboard navigation.
3. showToolbar={false} → Hides the toolbar for a cleaner static picker experience.

**After Fix:**
https://github.com/user-attachments/assets/7beaf74f-7666-453b-bdae-ce06169724b2

