### PR TITLE
Fix: Today  button action not updating date from year view in Static DatePicker (MUI v5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 ### Fixed
-
+- Fixed an issue in Static DatePicker (MUI) where the "Today" action did not correctly update or reflect the selected date when triggered from the year/month view.
 ### Changed
 
 ### Breaking changes

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  * ======================================================================== */
-import React, { KeyboardEvent } from 'react';
+import React, { KeyboardEvent, useState, useCallback } from 'react';
 import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatePickerProps } from '@mui/x-date-pickers/DatePicker';
 import { SvgIconProps, Theme } from '@mui/material';
 import { StaticDatePicker as MuiStaticDatePicker, StaticDatePickerProps as MuiStaticDatePickerProps } from '@mui/x-date-pickers/StaticDatePicker';
@@ -277,7 +277,7 @@ const DatePicker = <TInputDate, TDate>({
   const popperId = uuid();
   // Controls the active view of StaticDatePicker. Resets to 'day' on Today click since
   // MUI v5 StaticDatePicker does not reset the view automatically.
-  const [staticView, setStaticView] = React.useState<'day' | 'month' | 'year'>('day');
+  const [staticView, setStaticView] = useState<'day' | 'month' | 'year'>('day');
 
   const handleOnKeyDownLeft = (event: KeyboardEvent) => {
     if (event.key === 'ArrowRight') {
@@ -297,13 +297,13 @@ const DatePicker = <TInputDate, TDate>({
     }
   };
 
-  const handleStaticViewChange = React.useCallback((newView: 'day' | 'month' | 'year') => {
+  const handleStaticViewChange = useCallback((newView: 'day' | 'month' | 'year') => {
     setStaticView(newView);
     onViewChange?.(newView);
   }, [onViewChange]);
 
   // Today button fires onAccept — reset to 'day' view so the calendar returns from year/month view.
-  const handleStaticAccept = React.useCallback((acceptedValue: TDate | null) => {
+  const handleStaticAccept = useCallback((acceptedValue: TDate | null) => {
     setStaticView('day');
     onAccept?.(acceptedValue);
   }, [onAccept]);

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -270,6 +270,7 @@ const DatePicker = <TInputDate, TDate>({
   actionProps,
   customIcon,
   value,
+  onViewChange,
   onAccept,
   ...muiProps
 }: DatePickerProps<TInputDate, TDate>) => {
@@ -296,16 +297,16 @@ const DatePicker = <TInputDate, TDate>({
     }
   };
 
-  const handleStaticViewChange = (newView: 'day' | 'month' | 'year') => {
+  const handleStaticViewChange = React.useCallback((newView: 'day' | 'month' | 'year') => {
     setStaticView(newView);
-    if (muiProps.onViewChange) { muiProps.onViewChange(newView); }
-  };
+    onViewChange?.(newView);
+  }, [onViewChange]);
 
   // Today button fires onAccept — reset to 'day' view so the calendar returns from year/month view.
-  const handleStaticAccept = (acceptedValue: TDate | null) => {
+  const handleStaticAccept = React.useCallback((acceptedValue: TDate | null) => {
     setStaticView('day');
-    if (onAccept) { onAccept(acceptedValue); }
-  };
+    onAccept?.(acceptedValue);
+  }, [onAccept]);
 
   const formatValue = (dateValue: Dayjs, dateFormat: string): string => {
     return dateValue.format(dateFormat);
@@ -448,8 +449,9 @@ const DatePicker = <TInputDate, TDate>({
           {...muiProps as unknown as MuiStaticDatePickerProps<TInputDate, TDate>}
           disabled={disabled}
           value={value}
-          // view/onViewChange are forwarded to the internal CalendarPicker but not typed on StaticDatePickerProps.
-          {...{ view: staticView, onViewChange: handleStaticViewChange } as object}
+          // view is forwarded to the internal CalendarPicker but not typed on StaticDatePickerProps.
+          {...{ view: staticView } as object}
+          onViewChange={handleStaticViewChange}
           onAccept={handleStaticAccept}
           displayStaticWrapperAs={staticWrapperAs}
           closeOnSelect={false}

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -270,9 +270,13 @@ const DatePicker = <TInputDate, TDate>({
   actionProps,
   customIcon,
   value,
+  onAccept,
   ...muiProps
 }: DatePickerProps<TInputDate, TDate>) => {
   const popperId = uuid();
+  // Controls the active view of StaticDatePicker. Resets to 'day' on Today click since
+  // MUI v5 StaticDatePicker does not reset the view automatically.
+  const [staticView, setStaticView] = React.useState<'day' | 'month' | 'year'>('day');
 
   const handleOnKeyDownLeft = (event: KeyboardEvent) => {
     if (event.key === 'ArrowRight') {
@@ -290,6 +294,17 @@ const DatePicker = <TInputDate, TDate>({
         (element.previousElementSibling.previousElementSibling as HTMLButtonElement).focus();
       }
     }
+  };
+
+  const handleStaticViewChange = (newView: 'day' | 'month' | 'year') => {
+    setStaticView(newView);
+    if (muiProps.onViewChange) { muiProps.onViewChange(newView); }
+  };
+
+  // Today button fires onAccept — reset to 'day' view so the calendar returns from year/month view.
+  const handleStaticAccept = (acceptedValue: TDate | null) => {
+    setStaticView('day');
+    if (onAccept) { onAccept(acceptedValue); }
   };
 
   const formatValue = (dateValue: Dayjs, dateFormat: string): string => {
@@ -433,6 +448,9 @@ const DatePicker = <TInputDate, TDate>({
           {...muiProps as unknown as MuiStaticDatePickerProps<TInputDate, TDate>}
           disabled={disabled}
           value={value}
+          // view/onViewChange are forwarded to the internal CalendarPicker but not typed on StaticDatePickerProps.
+          {...{ view: staticView, onViewChange: handleStaticViewChange } as object}
+          onAccept={handleStaticAccept}
           displayStaticWrapperAs={staticWrapperAs}
           closeOnSelect={false}
           showToolbar={false}


### PR DESCRIPTION
**Issue:** When the user navigates to the year selection view and clicks on the "Today" button. The component does not switch back to the day view as well as does not clearly reflect the selected date
This results in a confusing user experience, where the action appears non-functional.

Root Cause
MUI does not automatically reset the view to 'day' on "Today" action.
The component remained in year/month view, preventing the user from seeing the selected date.

Before fix:
https://github.com/user-attachments/assets/58db4692-9960-4c16-b4c6-f53340e4fb2e

After Fix: 
https://github.com/user-attachments/assets/0949138c-640a-44bf-87d4-8db439909b11

