### PR TITLE
Fix StaticDatePicker not firing onChange on same date selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 - Fixed an issue in Static DatePicker (MUI) where the "Today" action did not correctly update or reflect the selected date when triggered from the year/month view.
-- Fixed an issue in Static DatePicker where re-selecting the already-selected date did not trigger `onChange`. MUI v5 `StaticDatePicker` suppresses `onChange` when the clicked day matches the current value; added a manual click handler in `renderDay` (static mode only) to re-fire the callback, allowing consumers to treat re-selection as a valid user action.
+- Fixed an issue in Static DatePicker where re-selecting the already-selected date did not trigger `onChange`.
 ### Changed
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Fixed an issue in Static DatePicker (MUI) where the "Today" action did not correctly update or reflect the selected date when triggered from the year/month view.
+- Fixed an issue in Static DatePicker where re-selecting the already-selected date did not trigger `onChange`. MUI v5 `StaticDatePicker` suppresses `onChange` when the clicked day matches the current value; added a manual click handler in `renderDay` (static mode only) to re-fire the callback, allowing consumers to treat re-selection as a valid user action.
 ### Changed
 
 ### Breaking changes

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -397,11 +397,13 @@ const DatePicker = <TInputDate, TDate>({
     // MUI v5 StaticDatePicker does not fire onChange when the user clicks an
     // already-selected day.  For static mode we attach a manual click handler
     // so that re-selecting the current date still notifies the consumer.
-    // The handler is omitted entirely for the regular (non-static) DatePicker
-    // so that MUI's built-in behaviour is preserved there.
-    const handleDayClick = (staticMode && DayComponentProps.selected)
-      ? () => { muiProps.onChange?.(day); }
-      : undefined;
+    // The onClick is only spread in static mode so that the non-static
+    // DatePicker's built-in MUI click behaviour is never overridden.
+    const handleDayClick = () => {
+      if (staticMode && DayComponentProps.selected) {
+        muiProps?.onChange?.(day);
+      }
+    };
 
     return (
       <Badge
@@ -443,7 +445,7 @@ const DatePicker = <TInputDate, TDate>({
           },
         }}
       >
-        <PickersDay {...DayComponentProps} {...(handleDayClick && { onClick: handleDayClick })} />
+        <PickersDay {...DayComponentProps} {...(staticMode && { onClick: handleDayClick })} />
       </Badge>
     );
   };

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -394,6 +394,15 @@ const DatePicker = <TInputDate, TDate>({
   };
 
   const renderDay = (day: TDate, _value: TDate[], DayComponentProps: PickersDayProps<TDate>) => {
+    // MUI v5 StaticDatePicker does not fire onChange when the user clicks an
+    // already-selected day.  For static mode we attach a manual click handler
+    // so that re-selecting the current date still notifies the consumer.
+    // The handler is omitted entirely for the regular (non-static) DatePicker
+    // so that MUI's built-in behaviour is preserved there.
+    const handleDayClick = (staticMode && DayComponentProps.selected)
+      ? () => { muiProps.onChange?.(day); }
+      : undefined;
+
     return (
       <Badge
         key={(day as unknown as Date).toString()}
@@ -434,7 +443,7 @@ const DatePicker = <TInputDate, TDate>({
           },
         }}
       >
-        <PickersDay {...DayComponentProps} />
+        <PickersDay {...DayComponentProps} {...(handleDayClick && { onClick: handleDayClick })} />
       </Badge>
     );
   };


### PR DESCRIPTION
Description
Fixes MUI v5 StaticDatePicker not triggering onChange on re-selecting the same date. Added a conditional onClick in renderDay (scoped to staticMode) to manually fire onChange for already selected dates, aligning with expected UX.