### PR TITLE
fix Select dropdown positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+- Fixed Select dropdown menu positioning and overlap by anchoring to the bottom of the input field.
 
 ### Changed
 

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -196,21 +196,11 @@ const renderInput = (props: SelectProps, id?: string) => {
   // Also we have to support the option that some stylings will handover via the MenuProps?.PaperProps?.style.
   const defaultStyle = {
     width: props.fullWidth ? '100%' : '240px',
-    // eslint-why - using nested ternary to reduce unnecessary code blocks
-    // eslint-disable-next-line no-nested-ternary
-    marginLeft: props.fullWidth ? '0px' : (theme.direction === ThemeDirectionType.RTL ? '8px' : '-8px'),
-    marginTop: '21px',
     padding: '0',
   };
   const paperPropsStyle = selectProps.MenuProps?.PaperProps?.style ? selectProps.MenuProps?.PaperProps?.style : defaultStyle;
   if (!paperPropsStyle.width) {
     paperPropsStyle.width = defaultStyle.width;
-  }
-  if (!paperPropsStyle.marginLeft) {
-    paperPropsStyle.marginLeft = defaultStyle.marginLeft;
-  }
-  if (!paperPropsStyle.marginTop) {
-    paperPropsStyle.marginTop = defaultStyle.marginTop;
   }
 
   return (
@@ -222,7 +212,7 @@ const renderInput = (props: SelectProps, id?: string) => {
       MenuProps={{
         ...selectProps.MenuProps,
         transformOrigin: { vertical: 'top', horizontal: theme.direction === ThemeDirectionType.RTL ? 'right' : 'left' },
-        anchorOrigin: { vertical: 'top', horizontal: theme.direction === ThemeDirectionType.RTL ? 'right' : 'left' },
+        anchorOrigin: { vertical: 'bottom', horizontal: theme.direction === ThemeDirectionType.RTL ? 'right' : 'left' },
         PaperProps: {
           style: paperPropsStyle,
           elevation: 2,


### PR DESCRIPTION
Removes explicit margin top offset that was accounting for the height of the Select input field. We can instead anchor the Menu to the bottom edge of the field instead. This change aligns with UX design.

The marginLeft -8px offset was also removed because it was causing the menu to be off-center once the anchorOrigin positioning was fixed.

Before fix (https://opensource.hcltechsw.com/enchanted-react-components/?path=/story/inputs-select-single--example-single-select):
<img width="276" height="169" alt="image" src="https://github.com/user-attachments/assets/2966236a-4d49-4e8d-be2b-2b712d029646" />

After fix:
<img width="283" height="185" alt="image" src="https://github.com/user-attachments/assets/af10ba16-f840-4741-a4e6-9a50e172a1d4" />
