### PR TITLE
Bug/flickering icons in progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Fixed Select dropdown menu positioning and overlap by anchoring to the bottom of the input field.
+- Fixed the ListItem CSS to stop flicking frequently while hovering.
 
 ### Changed
 

--- a/src/composite_components/ProgressBar/ProgressItems.tsx
+++ b/src/composite_components/ProgressBar/ProgressItems.tsx
@@ -145,6 +145,11 @@ const StyledList = styled(List)((props) => {
             },
           },
         },
+        '& .MuiListItemSecondaryAction-root': {
+          '.IconButtonMainContainer': {
+            margin: '0',
+          },
+        },
         '&:hover .MuiListItemText-primary, &:hover .MuiListItemText-secondary': {
           width: 'unset',
         },


### PR DESCRIPTION
Issue: In the ProgressBar, after uploading files and hovering on the icon in the List, it was flickering.

Fix: The issue caused by the styling in the ProgressList. Fixed it by adjusting the padding.
<img width="690" height="394" alt="image" src="https://github.com/user-attachments/assets/cd0c4f99-6ef0-4e6d-b131-7a80834badd2" />
